### PR TITLE
Reduce testing workflow to ubuntu only

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,25 +4,16 @@ on: [push, pull_request]
 
 jobs:
   build:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up repository
         uses: actions/checkout@main
 
-      - name: Set up repository
-        uses: actions/checkout@main
-        with:
-          ref: master
-
       - name: Merge to master
         run: git checkout --progress --force ${{ github.sha }}
 
-      - name: Run repository-wide tests
-        if: runner.os == 'Linux'
+      - name: Run repository-wide formatting checks
         working-directory:  ${{ github.workspace }}/.github
         run: ./run-checks.sh
 
@@ -39,7 +30,6 @@ jobs:
         run: ./gradlew check coverage
 
       - uses: codecov/codecov-action@v1
-        if: runner.os == 'Linux'
         with:
           file: ${{ github.workspace }}/build/reports/jacoco/coverage/coverage.xml
           fail_ci_if_error: true


### PR DESCRIPTION
1. Main issue due to tests on macOS and Windows platform (1-3 mins) are longer and more variable compared to on ubuntu (1 min), which can delay PR review and approval times. Even more problematic when jobs end up being queued to run due to low availability on GitHub end.

2. Java is written to be inherently cross-platform, so most routines (except low level system calls + absolute paths, the latter unlikely if relative paths are adhered to and are also easily detectable) are platform-independent anyway.

3. Reviewers can approve simple PRs (especially documentation ones) quickly due to the current Telegram notification workflow.