### PR TITLE
Add new Telegram notification events to workflow

### DIFF
--- a/.github/workflows/notifytele.yml
+++ b/.github/workflows/notifytele.yml
@@ -5,30 +5,61 @@
 # sendMessage to desired Telegram group chat. Circumvented by using `pull_request_target` that runs the action
 # in the context of the base forked commit for security.
 #
-# References:
-# - Guide for telegram-action: https://dev.to/nikhilvemula/get-notified-via-telegram-when-pull-request-is-raised-4ha4
-# - About GitHub secrets: https://docs.github.com/en/actions/reference/encrypted-secrets
-# - Why PR_target: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
-# - PR target descriptor: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
-# - Retrieving pull request number: https://github.community/t/how-to-get-the-github-pull-request-id-number/126558/2
+# Runs when the following events are triggered:
+# 1. opened : pull request is newly opened
+# 2. reopened : pull request (that was previously closed) is re-opened
+# 3. synchronize : commit(s) were pushed to pull request (including base branch fast forwards)
+# 4. closed : pull request is closed (be it merged or not merged)
 
 name: Telegram PR notification
 on:
   pull_request_target:
-    branches: [ master ]  # only PR to master branch invokes workflow
-    types: [ opened ]     # 'synchronize' -> update, 'edited' -> modified
+    types: [ opened, reopened, synchronize, closed ]
 
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
-    - name: Send notification
-      uses: appleboy/telegram-action@beaf02496b42e8584e144c9ef273af028f51f616  # lock-in to fixed commit
+    - name: Send notification (opened)
+      if: github.event.action == 'opened'
+      uses: appleboy/telegram-action@beaf02496b42e8584e144c9ef273af028f51f616
       with:
         to: ${{ secrets.TELEGRAM_TO }}
         token: ${{ secrets.TELEGRAM_TOKEN }}
         format: markdown
         message: |
-          New PR created:
-          [#${{ github.event.pull_request.number }}](https://github.com/AY2021S2-CS2103-W16-3/tp/pull/${{ github.event.pull_request.number }})
+          New PR opened: [#${{ github.event.number }}](${{ github.event.pull_request.html_url }})
+          Opened by: ${{ github.event.sender.login }}
+
+    - name: Send notification (synchronize, reopened)
+      if: github.event.action == 'synchronize' || github.event.action == 'reopened'
+      uses: appleboy/telegram-action@beaf02496b42e8584e144c9ef273af028f51f616
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        format: markdown
+        message: |
+          PR updated: [#${{ github.event.number }}](${{ github.event.pull_request.html_url }})
+          Updated by: ${{ github.event.sender.login }}
+
+    - name: Send notification (closed)
+      if: github.event.action == 'closed' && !github.event.pull_request.merged
+      uses: appleboy/telegram-action@beaf02496b42e8584e144c9ef273af028f51f616
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        format: markdown
+        message: |
+          PR closed (without merging): [#${{ github.event.number }}](${{ github.event.pull_request.html_url }})
+          Closed by: ${{ github.event.sender.login }}
+
+    - name: Send notification (merged)
+      if: github.event.action == 'closed' && github.event.pull_request.merged
+      uses: appleboy/telegram-action@beaf02496b42e8584e144c9ef273af028f51f616
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        format: markdown
+        message: |
+          PR merged: [#${{ github.event.number }}](${{ github.event.pull_request.html_url }})
+          Merged by: ${{ github.event.sender.login }}

--- a/.github/workflows/notifytele.yml
+++ b/.github/workflows/notifytele.yml
@@ -14,6 +14,7 @@
 name: Telegram PR notification
 on:
   pull_request_target:
+    branches: [ master ]
     types: [ opened, reopened, synchronize, closed ]
 
 jobs:
@@ -29,7 +30,6 @@ jobs:
         format: markdown
         message: |
           New PR opened: [#${{ github.event.number }}](${{ github.event.pull_request.html_url }})
-          Opened by: ${{ github.event.sender.login }}
 
     - name: Send notification (synchronize, reopened)
       if: github.event.action == 'synchronize' || github.event.action == 'reopened'


### PR DESCRIPTION
Adds new notification events (reopened, synchronized, closed, merged) for better visibility in Telegram group, as well as specifies user that triggered event.

Motivation: Tendency to reply opened PR message with `closed` for signaling, which can be automated here as well.

Food for thought: Can signal failed tests as well, but then again onus should be on the person opening the PR to verify, not the whole development team.