### PR TITLE
Increases vertical height of result display

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,7 +40,7 @@
         </StackPane>
 
         <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
+                   minHeight="150" prefHeight="150">
           <padding>
             <Insets top="5" right="10" bottom="5" left="10" />
           </padding>


### PR DESCRIPTION
Resolves #76, by adding more vertical height to the result pane. In particular, 150px is chosen to fit four lines + horizontal scroll (in the case of the `edit` command without parameters, see screenshot).

![image](https://user-images.githubusercontent.com/28663438/110266129-26880f00-7ff8-11eb-9d5a-3f1adee2e03c.png)