### PR TITLE
Add long-form prefixes

### DIFF
--- a/src/main/java/seedu/partyplanet/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/ArgumentMultimap.java
@@ -55,6 +55,6 @@ public class ArgumentMultimap {
      * Returns the preamble (text before the first valid prefix). Trims any leading/trailing spaces.
      */
     public String getPreamble() {
-        return getValue(new Prefix("")).orElse("");
+        return getValue(new Prefix()).orElse("");
     }
 }

--- a/src/main/java/seedu/partyplanet/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/ArgumentTokenizer.java
@@ -47,25 +47,24 @@ public class ArgumentTokenizer {
     private static List<PrefixPosition> findPrefixPositions(String argsString, Prefix prefix) {
         List<PrefixPosition> positions = new ArrayList<>();
 
-        int prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), 0);
-        while (prefixPosition != -1) {
-            PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
+        PrefixPosition extendedPrefix = findPrefixPosition(argsString, prefix, 0);
+        while (extendedPrefix != null) {
             positions.add(extendedPrefix);
-            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
+            extendedPrefix = findPrefixPosition(argsString, prefix, extendedPrefix.getStartPosition());
         }
 
         return positions;
     }
 
     /**
-     * Returns the index of the first occurrence of {@code prefix} in
+     * Returns the index of the first occurrence of any prefix string from {@code prefix} in
      * {@code argsString} starting from index {@code fromIndex}, including the
      * preceding whitespace. An occurrence
      * is valid if there is both a whitespace preceding and following {@code prefix},
      * or if the following whitespace is replaced by the end of string.
-     * Returns -1 if no such occurrence can be found.
+     * Returns null if no such occurrence can be found.
      *
-     * e.g Assume {@code fromIndex} = 0, {@code prefix} = "-p":
+     * e.g Assume {@code fromIndex} = 0, {@code prefix} = "-p, --prefix":
      *
      * - {@code argsString} = "-e abc-d" returns -1
      * - {@code argsString} = "-p abc-d" returns -1
@@ -73,18 +72,31 @@ public class ArgumentTokenizer {
      * - {@code argsString} = " -pp abc-d" returns -1
      * - {@code argsString} = "-e abc-d -p -d" returns 9
      * - {@code argsString} = "-e abc-d -p" returns 9
+     * - {@code argsString} = "-e abc-d --prefix" returns 9
      */
-    private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
-        int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
-        if (prefixIndex == -1) {
-            return -1; // invalid index
+    private static PrefixPosition findPrefixPosition(String argsString, Prefix prefix, int fromIndex) {
+        int minPrefixIndex = argsString.length();
+        String minPrefixString = null;
+
+        // Inevitable loop over possible prefixes due to recursive nature of search in `findPrefixPositions`.
+        // Since spaces between prefixes are required, to change to split -> iterative find method.
+        for (String prefixString: prefix.getPrefixes()) {
+            int prefixIndex = argsString.indexOf(" " + prefixString, fromIndex);
+            if (prefixIndex != -1 && prefixIndex < minPrefixIndex) {
+                minPrefixIndex = prefixIndex;
+                minPrefixString = prefixString;
+            }
+        }
+        if (minPrefixString == null) {
+            return null; // invalid index
         }
 
-        int trailingIndex = prefixIndex + 1 + prefix.length(); // index of character after prefix
+        int trailingIndex = minPrefixIndex + 1 + minPrefixString.length(); // index of character after prefix
         if (trailingIndex == argsString.length() || argsString.charAt(trailingIndex) == ' ') {
-            return prefixIndex + 1; // valid trailing character, +1 for leading whitespace
+            // valid trailing character, +1 for leading whitespace
+            return new PrefixPosition(minPrefixString, prefix, minPrefixIndex + 1);
         }
-        return -1;
+        return null;
     }
 
     /**
@@ -125,9 +137,9 @@ public class ArgumentTokenizer {
     private static String extractArgumentValue(String argsString,
                                         PrefixPosition currentPrefixPosition,
                                         PrefixPosition nextPrefixPosition) {
-        Prefix prefix = currentPrefixPosition.getPrefix();
+        String prefixString = currentPrefixPosition.getPrefixString();
 
-        int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
+        int valueStartPos = currentPrefixPosition.getStartPosition() + prefixString.length();
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
 
         return value.trim();
@@ -138,15 +150,21 @@ public class ArgumentTokenizer {
      */
     private static class PrefixPosition {
         private final int startPosition;
+        private final String prefixString;
         private final Prefix prefix;
 
-        PrefixPosition(Prefix prefix, int startPosition) {
+        PrefixPosition(String prefixString, Prefix prefix, int startPosition) {
+            this.prefixString = prefixString;
             this.prefix = prefix;
             this.startPosition = startPosition;
         }
 
         int getStartPosition() {
             return startPosition;
+        }
+
+        String getPrefixString() {
+            return prefixString;
         }
 
         Prefix getPrefix() {

--- a/src/main/java/seedu/partyplanet/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/ArgumentTokenizer.java
@@ -102,9 +102,9 @@ public class ArgumentTokenizer {
         prefixPositions.sort((prefix1, prefix2) -> prefix1.getStartPosition() - prefix2.getStartPosition());
 
         // Add PrefixPositions at start and end to represent preamble and end of string
-        PrefixPosition preambleMarker = new PrefixPosition(new Prefix(""), 0);
+        PrefixPosition preambleMarker = new PrefixPosition("", new Prefix(), 0);
         prefixPositions.add(0, preambleMarker);
-        PrefixPosition endPositionMarker = new PrefixPosition(new Prefix(""), argsString.length());
+        PrefixPosition endPositionMarker = new PrefixPosition("", new Prefix(), argsString.length());
         prefixPositions.add(endPositionMarker);
 
         // Create a map of prefixes to argument (if any)

--- a/src/main/java/seedu/partyplanet/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/CliSyntax.java
@@ -6,13 +6,19 @@ package seedu.partyplanet.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("-n");
-    public static final Prefix PREFIX_PHONE = new Prefix("-p");
-    public static final Prefix PREFIX_EMAIL = new Prefix("-e");
-    public static final Prefix PREFIX_BIRTHDAY = new Prefix("-b");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("-a");
-    public static final Prefix PREFIX_TAG = new Prefix("-t");
-    public static final Prefix PREFIX_FIND = new Prefix("-f");
-    public static final Prefix PREFIX_SORT = new Prefix("-s");
+    public static final Prefix PREFIX_NAME = new Prefix("-n", "--name");
+    public static final Prefix PREFIX_PHONE = new Prefix("-p", "--phone");
+    public static final Prefix PREFIX_EMAIL = new Prefix("-e", "--email");
+    public static final Prefix PREFIX_BIRTHDAY = new Prefix("-b", "--birthday");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("-a", "--address");
+    public static final Prefix PREFIX_TAG = new Prefix("-t", "--tag");
+    public static final Prefix PREFIX_FIND = new Prefix("-f", "--find");
+    public static final Prefix PREFIX_SORT = new Prefix("-s", "--sort");
+
+    /* Flag definitions */
+    public static final Prefix FLAG_ANY = new Prefix("--any");
+    public static final Prefix FLAG_APPEND = new Prefix("--append");
+    public static final Prefix FLAG_DELETE = new Prefix("--delete");
+    public static final Prefix FLAG_PARTIAL = new Prefix("--partial");
 
 }

--- a/src/main/java/seedu/partyplanet/logic/parser/Prefix.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/Prefix.java
@@ -1,27 +1,80 @@
 package seedu.partyplanet.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * A prefix that marks the beginning of an argument in an arguments string.
  * E.g. '-t' in 'add James -t friend'.
  */
 public class Prefix {
-    private final String prefix;
 
-    public Prefix(String prefix) {
-        this.prefix = prefix;
+    private static final Set<String> allPrefixes = new HashSet<>();
+    private final String representativePrefix;
+    private final HashSet<String> prefixes;
+
+    /**
+     * Empty constructor for placeholder prefixes.
+     * Used for placeholders, when a generic prefix is needed.
+     */
+    public Prefix() {
+        this.representativePrefix = "";
+        this.prefixes = new HashSet<>();
     }
 
+    /**
+     * Basic Prefix constructor.
+     * Should never be initialized by user / user routine, due to checks on prefix duplicates
+     * for developer safety. Where a generic Prefix is required, use the empty constructor {@code Prefix()} instead.
+     *
+     * @param prefix The prefix string representing the Prefix
+     * @param altPrefixes Array of alternate prefix aliases
+     */
+    public Prefix(String prefix, String... altPrefixes) {
+        requireNonNull(prefix);
+        assert !prefix.equals(""); // ensure default value of empty constructor never initialized
+        this.representativePrefix = prefix;
+        this.prefixes = new HashSet<>(Arrays.asList(altPrefixes));
+        this.prefixes.add(prefix);
+        assertNoDuplicatePrefixes(this.prefixes);
+    }
+
+    /**
+     * Raises runtime assertion if initialization of prefixes contain duplicates, for developer safety.
+     *
+     * @param prefixes Set of new prefix strings.
+     */
+    private static void assertNoDuplicatePrefixes(Set<String> prefixes) {
+        int previousSize = allPrefixes.size();
+        allPrefixes.addAll(prefixes);
+        assert allPrefixes.size() == previousSize + prefixes.size();
+    }
+
+    /**
+     * Returns the representative prefix representing the set of prefixes.
+     */
     public String getPrefix() {
-        return prefix;
+        return representativePrefix;
     }
 
+    /**
+     * Returns all equivalent forms of the same prefix.
+     */
+    public Set<String> getPrefixes() {
+        return this.prefixes;
+    }
+
+    @Override
     public String toString() {
         return getPrefix();
     }
 
     @Override
     public int hashCode() {
-        return prefix == null ? 0 : prefix.hashCode();
+        return representativePrefix.hashCode();
     }
 
     @Override

--- a/src/test/java/seedu/partyplanet/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/partyplanet/logic/parser/ArgumentTokenizerTest.java
@@ -2,17 +2,16 @@ package seedu.partyplanet.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 public class ArgumentTokenizerTest {
 
-    private final Prefix unknownPrefix = new Prefix("--u");
-    private final Prefix pSlash = new Prefix("p/");
-    private final Prefix dashT = new Prefix("-t");
-    private final Prefix hatQ = new Prefix("^Q");
+    private static final Prefix unknownPrefix = new Prefix("--u");
+    private static final Prefix pSlash = new Prefix("p/");
+    private static final Prefix dashTT = new Prefix("-TT");
+    private static final Prefix hatQ = new Prefix("^Q");
 
     @Test
     public void tokenize_emptyArgsString_noValues() {
@@ -82,19 +81,19 @@ public class ArgumentTokenizerTest {
     @Test
     public void tokenize_multipleArguments() {
         // Only two arguments are present
-        String argsString = "SomePreambleString -t dashT-Value p/ pSlash value";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        String argsString = "SomePreambleString -TT dashTT-Value p/ pSlash value";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashTT, hatQ);
         assertPreamblePresent(argMultimap, "SomePreambleString");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value");
+        assertArgumentPresent(argMultimap, dashTT, "dashTT-Value");
         assertArgumentAbsent(argMultimap, hatQ);
 
         // All three arguments are present
-        argsString = "Different Preamble String ^Q 111 -t dashT-Value p/ pSlash value";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        argsString = "Different Preamble String ^Q 111 -TT dashTT-Value p/ pSlash value";
+        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashTT, hatQ);
         assertPreamblePresent(argMultimap, "Different Preamble String");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value");
+        assertArgumentPresent(argMultimap, dashTT, "dashTT-Value");
         assertArgumentPresent(argMultimap, hatQ, "111");
 
         /* Also covers: Reusing of the tokenizer multiple times */
@@ -102,7 +101,7 @@ public class ArgumentTokenizerTest {
         // Reuse tokenizer on an empty string to ensure ArgumentMultimap is correctly reset
         // (i.e. no stale values from the previous tokenizing remain)
         argsString = "";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashTT, hatQ);
         assertPreambleEmpty(argMultimap);
         assertArgumentAbsent(argMultimap, pSlash);
 
@@ -110,7 +109,7 @@ public class ArgumentTokenizerTest {
 
         // Prefixes not previously given to the tokenizer should not return any values
         argsString = unknownPrefix + "some value";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashTT, hatQ);
         assertArgumentAbsent(argMultimap, unknownPrefix);
         assertPreamblePresent(argMultimap, argsString); // Unknown prefix is taken as part of preamble
     }
@@ -118,33 +117,22 @@ public class ArgumentTokenizerTest {
     @Test
     public void tokenize_multipleArgumentsWithRepeats() {
         // Two arguments repeated, some have empty values
-        String argsString = "SomePreambleString -t dashT-Value ^Q ^Q -t another dashT value p/ pSlash value -t";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        String argsString = "SomePreambleString -TT dashTT-Value ^Q ^Q -TT another dashTT value p/ pSlash value -TT";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashTT, hatQ);
         assertPreamblePresent(argMultimap, "SomePreambleString");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
-        assertArgumentPresent(argMultimap, dashT, "dashT-Value", "another dashT value", "");
+        assertArgumentPresent(argMultimap, dashTT, "dashTT-Value", "another dashTT value", "");
         assertArgumentPresent(argMultimap, hatQ, "", "");
     }
 
     @Test
     public void tokenize_multipleArgumentsJoined() {
-        String argsString = "SomePreambleStringp/ pSlash joined-tjoined -t not joined^Qjoined";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        String argsString = "SomePreambleStringp/ pSlash joined-tjoined -TT not joined^Qjoined";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashTT, hatQ);
         assertPreamblePresent(argMultimap, "SomePreambleStringp/ pSlash joined-tjoined");
         assertArgumentAbsent(argMultimap, pSlash);
-        assertArgumentPresent(argMultimap, dashT, "not joined^Qjoined");
+        assertArgumentPresent(argMultimap, dashTT, "not joined^Qjoined");
         assertArgumentAbsent(argMultimap, hatQ);
-    }
-
-    @Test
-    public void equalsMethod() {
-        Prefix aaa = new Prefix("aaa");
-
-        assertEquals(aaa, aaa);
-        assertEquals(aaa, new Prefix("aaa"));
-
-        assertNotEquals(aaa, "aaa");
-        assertNotEquals(aaa, new Prefix("aab"));
     }
 
 }

--- a/src/test/java/seedu/partyplanet/logic/parser/PrefixTest.java
+++ b/src/test/java/seedu/partyplanet/logic/parser/PrefixTest.java
@@ -1,0 +1,30 @@
+package seedu.partyplanet.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class PrefixTest {
+
+    @Test
+    public void invalidOrDuplicatePrefixes() {
+        Prefix abc = new Prefix("_test_abc");
+        try {
+            Prefix abc2 = new Prefix("_test_abc");
+        } catch (AssertionError e) {
+            return;
+        }
+        throw new AssertionError("Duplicate prefixes should not be allowed.");
+    }
+
+    @Test
+    public void equalsMethod() {
+        Prefix aaa = new Prefix("_test_aaa");
+
+        assertEquals(aaa, aaa);
+
+        assertNotEquals(aaa, "_test_aaa");
+        assertNotEquals(aaa, new Prefix("_test_aab"));
+    }
+}


### PR DESCRIPTION
See individual commit description for further details. Fixes #103 and part of #102.
In short, supports `add --name John --birthday 2020-01-01` (as alternatives to `-n` and `-b`) and other prefixes specified in the linked issues. See [`CliSyntax`](https://github.com/pyuxiang/tp/blob/branch-addLongPrefix/src/main/java/seedu/partyplanet/logic/parser/CliSyntax.java) class for the complete list of alternative prefixes added.

Required follow up:
- Document long form prefixes in UG and in `help` command.

### Notable side-effect
Since duplicate prefix strings may be introduced inadvertently by developers when introducing new / alternative prefixes, a static assertion is added to `Prefix` to check for such duplicated prefixes. An unintended side-effect is a whole host of test cases failing in such instances, with the first failed case notably being the AssertionError thrown by `Prefix.assertNoDuplicatePrefixes`. See image below:

Ideas to change this behavior, such that only the single `PrefixTest.invalidOrDuplicatePrefixes` test case fails without affecting the initialization of the CliSyntax class, are welcome (perhaps in future iterations). Same goes to checking that `Prefix("")` is never called.

![image](https://user-images.githubusercontent.com/28663438/111151709-caf6ec00-85ca-11eb-91a1-b033847b7fab.png)

edit:

To further elaborate the algorithm behind the parser:

### Original implementation

Original idea uses the whole string `argsString`. For each prefix to be searched (specified in the respective commands), a left substring search is performed, i.e. the prefix is repeatedly matched starting from the left of `argsString`, until all the positions are identified (stored as `PrefixPosition` containing prefix and position), e.g.

For prefix `-t` and string `add -t friend -n John -t colleague -t $$$`, the search proceeds in the following manner:
- `add [-t] friend -n John -t colleague -t $$$` -> create prefixPosition
- `friend -n John [-t] colleague -t $$$` -> create prefixPosition
- `colleague [-t] $$$` -> create prefixPosition
- `$$$`

The same is done for the rest of the prefixes. All the prefixPositions are then sorted in increasing positional order (with extra placeholders at start and end), and these are used to delineate the start and end of each argument - which are then trimmed.

### Proposed implementation

For each `Prefix`, we assign a variable number of string arguments to act as alternative equivalent prefix strings, but the first argument is the representative prefix string. Think it similar to a Union-Find data structure. The representative string is additionally used for equality checking, nothing more nothing less. All specified strings are stored in a set and used to do the substring search above.

For substring search, we employ a similar left-to-right procedure, except that now we pick the position associated with the leftmost position across all prefixes in `Prefix` to guarantee left-to-right search. This is the `minPrefixString` part, which is passed to `PrefixPosition`.

The `PrefixPosition` is used for two things: (1) mark positions of prefix in string, (2) store prefix to retrieve length of prefix *and* pass to `ArgumentMultimap` for retrieval later. Because we're dealing with multiple possible prefix alternatives, this necessitates the `PrefixPosition` to store the prefix string itself (or at least the length of the prefix string) to demarcate the start and end of each argument.

To deal with concerns over possible developer error when specifying alternative prefixes, the static check `assertNoDuplicatePrefixes` is added which does a union over all instantiated `Prefix`s at compile time to check for duplicates. The rest are test case updates, empty `Prefix` to allow placeholders, and shifting `Prefix` test cases to dedicated test suite.