### PR TITLE
Modify delete command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -63,13 +63,14 @@ Examples:
 ### Clearing all data : `clear`
 
 Deprecated: essentially same function as `delete`
+
 Removes all contacts from the PartyPlanet's Contact List.
 
 Format: `clear`
 
 ### Deleting contacts : `delete`
 
-Deletes the specified person from the PartyPlanet's Contact List.
+Deletes person(s) from the PartyPlanet's Contact List.
 
 Format: `delete [{INDEX [INDEX]... | -t TAG [-t TAG]...}]`
 * If no parameters:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -62,6 +62,7 @@ Examples:
 
 ### Clearing all data : `clear`
 
+Deprecated: essentially same function as `delete`
 Removes all contacts from the PartyPlanet's Contact List.
 
 Format: `clear`
@@ -70,7 +71,9 @@ Format: `clear`
 
 Deletes the specified person from the PartyPlanet's Contact List.
 
-Format: `delete {INDEX [INDEX]... | -t TAG [-t TAG]...}`
+Format: `delete [{INDEX [INDEX]... | -t TAG [-t TAG]...}]`
+* If no parameters:
+  * Deletes all contacts in the current filtered list
 * If provided with index(es)
   * Deletes the person at the specified `INDEX`.
   * All indexes refers to the index number shown in the displayed person list (without sorting).
@@ -80,6 +83,7 @@ Format: `delete {INDEX [INDEX]... | -t TAG [-t TAG]...}`
   * If the person is tagged with another tag, only the specified tag will be removed. The contact will not be deleted.
 
 Examples:
+* `delete` deletes all contacts in current filtered list
 * `delete 3` deletes contact at 3rd index.
 * `delete 3 4 5` deletes contacts at 3rd, 4th and 5th index.
 * `delete -t colleague` deletes contact with tag "colleague".
@@ -197,7 +201,7 @@ Action | Format, Examples
 --------|------------------
 **Add** | `add -n NAME [-p PHONE_NUM] [-e EMAIL] [-a ADDRESS] [-t TAG]…​ [-b BIRTHDAY] [-r REMARK]` <br> e.g., `add -n James Ho -p 96280000 -t friend -t colleague -r allergic to nuts`
 **Clear** | `clear`
-**Delete** | `delete {INDEX [INDEX]... | -t TAG [-t TAG]...}`<br> e.g., `delete 3 4 5` <br> e.g., `delete -t colleague`
+**Delete** | `delete [{INDEX [INDEX]... | -t TAG [-t TAG]...}]`<br> e.g., `delete` <br> e.g., `delete 3 4 5` <br> e.g., `delete -t colleague`
 **Edit** | `edit INDEX [-n NAME] [-p PHONE_NUMBER] [-e EMAIL] [-a ADDRESS] [-t TAG]…​ [-b BIRTHDAY] [-r REMARK]`<br> e.g.,`edit 2 -n James Lee -e jameslee@example.com`<br> e.g., `edit 2 -n Betsy Crower -t colleague`
 **Find** | `find [-n NAME] [-t TAG]`<br> e.g., `find -n Bob -t cs2103`
 **List** | `list [-s SORT_ORDER]`<br> e.g., `list`<br> e.g., `list -s asc`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -74,7 +74,7 @@ Deletes person(s) from the PartyPlanet's Contact List.
 
 Format: `delete [{INDEX [INDEX]... | -t TAG [-t TAG]...}]`
 * If no parameters:
-  * Deletes all contacts in the current filtered list
+  * Deletes all persons in the current filtered list
 * If provided with index(es)
   * Deletes the person at the specified `INDEX`.
   * All indexes refers to the index number shown in the displayed person list (without sorting).

--- a/src/main/java/seedu/partyplanet/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/ClearCommand.java
@@ -7,6 +7,7 @@ import seedu.partyplanet.model.Model;
 
 /**
  * Clears PartyPlanet.
+ * Deprecated: effectively same as DeleteCommand in an unfiltered list.
  */
 public class ClearCommand extends Command {
 

--- a/src/main/java/seedu/partyplanet/logic/commands/DeleteClearCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/DeleteClearCommand.java
@@ -1,0 +1,50 @@
+package seedu.partyplanet.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import seedu.partyplanet.logic.commands.exceptions.CommandException;
+import seedu.partyplanet.model.Model;
+import seedu.partyplanet.model.person.Person;
+
+/**
+ * Deletes all person currently displayed.
+ */
+public class DeleteClearCommand extends DeleteCommand {
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = new ArrayList<>(model.getFilteredPersonList());
+        List<Person> deletedPersons = new ArrayList<>();
+
+        for (Person p : lastShownList) {
+            deletedPersons.add(p);
+            model.deletePerson(p);
+        }
+
+        // Only save state if there are changes (person deleted)
+        if (!deletedPersons.isEmpty()) {
+            model.addState();
+        }
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, displayPersons(deletedPersons)));
+    }
+
+    /**
+     * Returns list of persons in the form "a, b, c,..."
+     */
+    private String displayPersons(List<Person> deletedPersons) {
+        return deletedPersons.stream()
+                .map(p -> p.getName().toString())
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("None!");
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteClearCommand); // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/partyplanet/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/DeleteCommand.java
@@ -15,5 +15,5 @@ public abstract class DeleteCommand extends Command {
             + "Parameters: [{INDEX (must be a positive integer) [INDEX]... | -t TAG [-t TAG]...}]\n"
             + "Example: " + COMMAND_WORD + " 1 2 3";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted the following persons: %1$s";
 }

--- a/src/main/java/seedu/partyplanet/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/DeleteCommand.java
@@ -8,10 +8,11 @@ public abstract class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list\n"
+            + ": Deletes all contacts in currently filtered list\n"
+            + "OR Deletes the person identified by the index number used in the displayed person list\n"
             + "OR Delete the person with the provided tag,\n"
             + "unless the person has other tags, then only the tag is removed\n"
-            + "Parameters: {INDEX (must be a positive integer) [INDEX]... | -t TAG [-t TAG]...}\n"
+            + "Parameters: [{INDEX (must be a positive integer) [INDEX]... | -t TAG [-t TAG]...}]\n"
             + "Example: " + COMMAND_WORD + " 1 2 3";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";

--- a/src/main/java/seedu/partyplanet/logic/commands/DeleteContactWithTagCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/DeleteContactWithTagCommand.java
@@ -16,7 +16,7 @@ import seedu.partyplanet.model.tag.Tag;
  * Deletes all persons, that is tagged with the target tags, from PartyPlanet.
  * Provided that they do not have other tags.
  */
-public class DeleteTagCommand extends DeleteCommand {
+public class DeleteContactWithTagCommand extends DeleteCommand {
 
     public static final String MESSAGE_DELETE_TAGS_SUCCESS = "Deleted tags : %1$s";
 
@@ -25,9 +25,9 @@ public class DeleteTagCommand extends DeleteCommand {
     private final List<Person> deletedPersons;
 
     /**
-     * Creates an DeleteTagCommand to delete the {@code Person} with specified {@code Tag}
+     * Creates an DeleteContactWithTagCommand to delete the {@code Person} with specified {@code Tag}
      */
-    public DeleteTagCommand(Set<Tag> targetTags) {
+    public DeleteContactWithTagCommand(Set<Tag> targetTags) {
         this.targetTags = targetTags;
         deletedPersons = new ArrayList<>();
     }
@@ -41,7 +41,12 @@ public class DeleteTagCommand extends DeleteCommand {
         for (Person person : personList) {
             removePersonWithTags(model, person);
         }
-        model.addState();
+
+        // Only save state if there are changes (person deleted)
+        if (!deletedPersons.isEmpty()) {
+            model.addState();
+        }
+
         return new CommandResult(String.format(MESSAGE_DELETE_TAGS_SUCCESS, displayTags())
                 + (deletedPersons.isEmpty()
                 ? ""
@@ -106,7 +111,7 @@ public class DeleteTagCommand extends DeleteCommand {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof DeleteTagCommand // instanceof handles nulls
-                && targetTags.equals(((DeleteTagCommand) other).targetTags)); // state check
+                || (other instanceof DeleteContactWithTagCommand // instanceof handles nulls
+                && targetTags.equals(((DeleteContactWithTagCommand) other).targetTags)); // state check
     }
 }

--- a/src/main/java/seedu/partyplanet/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/HelpCommand.java
@@ -18,7 +18,7 @@ public class HelpCommand extends Command {
             + "add -n NAME [-p PHONE_NUM] [-e EMAIL] [-a ADDRESS] [-t TAG]…\u200B [-b BIRTHDAY]\u200B\n"
             + "Clearing all data: clear\n"
             + "Deleting contacts: "
-            + "delete {INDEX [INDEX]... | -t TAG [-t TAG]...}\n"
+            + "delete [{INDEX [INDEX]... | -t TAG [-t TAG]...}]\n"
             + "Editing contacts: "
             + "edit INDEX [-n NAME] [-p PHONE_NUMBER] [-e EMAIL] [-a ADDRESS] [-t TAG]…\u200B [-b BIRTHDAY]\n"
             + "Finding contacts: "

--- a/src/main/java/seedu/partyplanet/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/DeleteCommandParser.java
@@ -8,9 +8,10 @@ import java.util.List;
 import java.util.Set;
 
 import seedu.partyplanet.commons.core.index.Index;
+import seedu.partyplanet.logic.commands.DeleteClearCommand;
 import seedu.partyplanet.logic.commands.DeleteCommand;
 import seedu.partyplanet.logic.commands.DeleteContactCommand;
-import seedu.partyplanet.logic.commands.DeleteTagCommand;
+import seedu.partyplanet.logic.commands.DeleteContactWithTagCommand;
 import seedu.partyplanet.logic.parser.exceptions.ParseException;
 import seedu.partyplanet.model.tag.Tag;
 
@@ -30,15 +31,19 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         boolean tagIsPresent = argMultimap.getValue(PREFIX_TAG).isPresent();
         boolean idxIsPresent = !argMultimap.getPreamble().isEmpty();
 
-        // Only allow either tag exist or index exist
-        if (!(tagIsPresent ^ idxIsPresent)) {
+        // Do not allow both tag and index to exist
+        if (tagIsPresent && idxIsPresent) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+
+        if (!(tagIsPresent || idxIsPresent)) {
+            return new DeleteClearCommand();
         }
 
         try {
 
             if (tagIsPresent) {
-                return createDeleteTagCommand(argMultimap.getAllValues(PREFIX_TAG));
+                return createDeleteContactWithTagCommand(argMultimap.getAllValues(PREFIX_TAG));
             }
 
             return createDeleteContactCommand(argMultimap.getPreamble());
@@ -49,9 +54,9 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
     }
 
-    private DeleteTagCommand createDeleteTagCommand(List<String> tags) throws ParseException {
+    private DeleteContactWithTagCommand createDeleteContactWithTagCommand(List<String> tags) throws ParseException {
         Set<Tag> tagList = ParserUtil.parseTags(tags);
-        return new DeleteTagCommand(tagList);
+        return new DeleteContactWithTagCommand(tagList);
     }
 
     private DeleteContactCommand createDeleteContactCommand(String args) throws ParseException {


### PR DESCRIPTION
- Add `delete` command without parameters. It clears all person in filtered list

- Rename DeleteTagCommand -> DeleteContactWithTagCommand.
To make way for `delete tag` command.
Did not change functionality (will modify to delete all contact regardless of tags when adding `delete tag`).

- Add deprecated comment to `clear`.
Will remove `clear` later on when tests added for `delete` (ensured that working properly)


part of #102 