### PR TITLE
Implement partial and exact list filtering

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -107,6 +107,8 @@ Examples:
 
 ### Finding contacts : `find`
 
+Deprecated: essentially same function as `list`
+
 Finds persons whose names contain the given keywords and/or is associated with the given tag.
 
 Format: `find [-n NAME] [-t TAG]`
@@ -123,10 +125,13 @@ Examples:
 
 Shows a list of all persons in the PartyPlanet's Contact List.
 
-Format: `list [-s SORT_ORDER]`
-* List out all contacts by default.
-* `-s` list out all contacts sorted according to `SORT_ORDER`.
-* Possible values of `SORT_ORDER`:
+Format: `list [--partial] [--any] [-n NAME]... [-t TAG]... [-s SORT_ORDER]`
+* List out all contacts by default if no arguments specified.
+* `-n` and `-t` can be specified to filter the list by name and/or tag.
+  * Search is case-insensitive, e.g. `hans` will match `Hans`.
+  * Partial matches to names and tags are performed if `--partial` is specified, e.g. `lliam` will match `williams`.
+  * If multiple names/tags are specified, specifying `--any` filters contacts that fulfill any prefix match.
+* `-s` list out all contacts sorted according to `SORT_ORDER`. Possible values of `SORT_ORDER`:
   * `asc`: ascending lexicographical order
   * `desc`: descending lexicographical order
   * `bday`: in ascending order from Jan-01 to Dec-31
@@ -134,6 +139,11 @@ Format: `list [-s SORT_ORDER]`
 Examples:
 * `list` Lists out all the contacts in PartyPlanet.
 * `list -s asc` Lists out all the contacts in ascending lexicographical order.
+* `list -t friend` Lists out all contacts containing the tag "friend"
+* `list -n alice -t friend` Lists out all contacts whose name is "Alice" and have the "friend" tag
+* `list --any -n alice -t friend` Lists out all contacts whose name is "Alice" or who have the "friend" tag
+* `list --partial -n alice -t friend` Lists out all contacts whose name contain "Alice" and who have tags that contain "friend"
+* `list --partial --any -n alice -t friend` Lists out all contacts whose name contain "Alice" or who have tags that contain "friend"
 
 ### Finding tags : `tags`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -125,11 +125,12 @@ Examples:
 
 Shows a list of all persons in the PartyPlanet's Contact List.
 
-Format: `list [--partial] [--any] [-n NAME]... [-t TAG]... [-s SORT_ORDER]`
+Format: `list [--exact] [--any] [-n NAME]... [-t TAG]... [-s SORT_ORDER]`
 * List out all contacts by default if no arguments specified.
 * `-n` and `-t` can be specified to filter the list by name and/or tag.
   * Search is case-insensitive, e.g. `hans` will match `Hans`.
-  * Partial matches to names and tags are performed if `--partial` is specified, e.g. `lliam` will match `williams`.
+  * Partial matches to names and tags are performed by default, e.g. `lliam` will match `williams`.
+  * If exact match is desired, specify an additional `--exact` flag.
   * If multiple names/tags are specified, specifying `--any` filters contacts that fulfill any prefix match.
 * `-s` list out all contacts sorted according to `SORT_ORDER`. Possible values of `SORT_ORDER`:
   * `asc`: ascending lexicographical order
@@ -142,8 +143,8 @@ Examples:
 * `list -t friend` Lists out all contacts containing the tag "friend"
 * `list -n alice -t friend` Lists out all contacts whose name is "Alice" and have the "friend" tag
 * `list --any -n alice -t friend` Lists out all contacts whose name is "Alice" or who have the "friend" tag
-* `list --partial -n alice -t friend` Lists out all contacts whose name contain "Alice" and who have tags that contain "friend"
-* `list --partial --any -n alice -t friend` Lists out all contacts whose name contain "Alice" or who have tags that contain "friend"
+* `list --exact -n alice -t friend` Lists out all contacts whose name contain "Alice" and who have tags that contain "friend"
+* `list --exact --any -n alice -t friend` Lists out all contacts whose name contain "Alice" or who have tags that contain "friend"
 
 ### Finding tags : `tags`
 

--- a/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
@@ -75,8 +75,8 @@ public class ListCommand extends Command {
 
         // Filter by predicate
         Predicate<Person> overallPredicate;
-        if (isAnySearch && predicates.isEmpty()) {
-            overallPredicate = x -> true;
+        if (predicates.isEmpty()) {
+            overallPredicate = PREDICATE_SHOW_ALL_PERSONS;
         } else if (isAnySearch) {
             overallPredicate = x -> false;
             for (Predicate<Person> predicate: predicates) {

--- a/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
@@ -22,9 +22,9 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists people in PartyPlanet "
             + "according to specified prefix combinations, with optional sort order.\n"
-            + "Parameters: [--partial] [--any] [-n NAME]... [-t TAG]... [-s SORT_ORDER]\n"
+            + "Parameters: [--exact] [--any] [-n NAME]... [-t TAG]... [-s SORT_ORDER]\n"
             + "Sort Orders: asc (Name Ascending - Default), desc (Name Descending)\n"
-            + "Example: list --partial -n alice -t friend -s desc\n";
+            + "Example: list --exact -n alice -t friend -s desc\n";
 
     public static final Comparator<Person> ASC = (x, y) ->
         x.getName().fullName.compareTo(y.getName().fullName);

--- a/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
@@ -20,11 +20,11 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all persons in the PartyPlanet. "
-            + "Can take in a sort order to show the list by.\n"
-            + "Parameters: [-s SORT_ORDER]\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists people in PartyPlanet "
+            + "according to specified prefix combinations, with optional sort order.\n"
+            + "Parameters: [--partial] [--any] [-n NAME]... [-t TAG]... [-s SORT_ORDER]\n"
             + "Sort Orders: asc (Name Ascending - Default), desc (Name Descending)\n"
-            + "Example: list -s desc\n";
+            + "Example: list --partial -n alice -t friend -s desc\n";
 
     public static final Comparator<Person> ASC = (x, y) ->
         x.getName().fullName.compareTo(y.getName().fullName);

--- a/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
@@ -4,7 +4,10 @@ import static java.util.Objects.requireNonNull;
 import static seedu.partyplanet.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Comparator;
+import java.util.List;
+import java.util.function.Predicate;
 
+import seedu.partyplanet.commons.core.Messages;
 import seedu.partyplanet.model.Model;
 import seedu.partyplanet.model.person.Person;
 
@@ -31,16 +34,81 @@ public class ListCommand extends Command {
 
     private final Comparator<Person> comparator;
 
-    public ListCommand(Comparator<Person> comparator) {
+    private final List<Predicate<Person>> predicates;
+
+    private final boolean isAnySearch;
+
+    /**
+     * Default empty ListCommand.
+     * Shows the whole list.
+     */
+    public ListCommand() {
+        this(PREDICATE_SHOW_ALL_PERSONS);
+    }
+
+    /**
+     * More general ListCommand accepting a single filtering predicate.
+     * Default in ascending order, and the ANY flag is not applicable.
+     */
+    public ListCommand(Predicate<Person> predicate) {
+        this(List.of(predicate), false, ASC);
+    }
+
+    /**
+     * Most general ListCommand.
+     *
+     * @param predicates List of predicates to filter people by
+     * @param isAnySearch Whether filtering of predicates uses AND or OR boolean query
+     * @param comparator Sorting comparator
+     */
+    public ListCommand(List<Predicate<Person>> predicates,
+                       boolean isAnySearch,
+                       Comparator<Person> comparator) {
+        this.predicates = predicates;
+        this.isAnySearch = isAnySearch;
         this.comparator = comparator;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+
+        // Filter by predicate
+        Predicate<Person> overallPredicate;
+        if (isAnySearch && predicates.isEmpty()) {
+            overallPredicate = x -> true;
+        } else if (isAnySearch) {
+            overallPredicate = x -> false;
+            for (Predicate<Person> predicate: predicates) {
+                overallPredicate = overallPredicate.or(predicate);
+            }
+        } else {
+            overallPredicate = x -> true;
+            for (Predicate<Person> predicate: predicates) {
+                overallPredicate = overallPredicate.and(predicate);
+            }
+        }
         model.sortPersonList(comparator);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        model.updateFilteredPersonList(overallPredicate);
+        if (model.getPersonListCopy().size() == model.getFilteredPersonList().size()) {
+            return new CommandResult(ListCommand.MESSAGE_SUCCESS); // No person filtered out
+        }
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof ListCommand)) {
+            return false;
+        }
+        ListCommand command = (ListCommand) other;
+        return isAnySearch == command.isAnySearch
+                && comparator.equals(command.comparator)
+                && predicates.equals(((ListCommand) other).predicates); // state check
     }
 
 }

--- a/src/main/java/seedu/partyplanet/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/ArgumentMultimap.java
@@ -45,7 +45,7 @@ public class ArgumentMultimap {
      * Modifying the returned list will not affect the underlying data structure of the ArgumentMultimap.
      */
     public List<String> getAllValues(Prefix prefix) {
-        if (!argMultimap.containsKey(prefix)) {
+        if (!contains(prefix)) {
             return new ArrayList<>();
         }
         return new ArrayList<>(argMultimap.get(prefix));
@@ -56,5 +56,13 @@ public class ArgumentMultimap {
      */
     public String getPreamble() {
         return getValue(new Prefix("")).orElse("");
+    }
+
+    /**
+     * Returns true if {@code prefix} exists inside the map, else false.
+     * Typically for flag checking, where the values are not semantically meaningful.
+     */
+    public boolean contains(Prefix prefix) {
+        return argMultimap.containsKey(prefix);
     }
 }

--- a/src/main/java/seedu/partyplanet/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/CliSyntax.java
@@ -20,5 +20,5 @@ public class CliSyntax {
     public static final Prefix FLAG_ANY = new Prefix("--any");
     public static final Prefix FLAG_APPEND = new Prefix("--append");
     public static final Prefix FLAG_DELETE = new Prefix("--delete");
-    public static final Prefix FLAG_PARTIAL = new Prefix("--partial");
+    public static final Prefix FLAG_EXACT = new Prefix("--exact");
 }

--- a/src/main/java/seedu/partyplanet/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/CliSyntax.java
@@ -16,4 +16,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_FIND = new Prefix("-f");
     public static final Prefix PREFIX_SORT = new Prefix("-s");
 
+    public static final Prefix FLAG_PARTIAL = new Prefix("--partial");
+    public static final Prefix FLAG_ANY = new Prefix("--any");
 }

--- a/src/main/java/seedu/partyplanet/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/ListCommandParser.java
@@ -38,6 +38,10 @@ public class ListCommandParser implements Parser<ListCommand> {
         ArgumentMultimap argMap = ArgumentTokenizer.tokenize(
                 args, PREFIX_NAME, PREFIX_TAG, PREFIX_SORT, FLAG_EXACT, FLAG_ANY);
 
+        if (!argMap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        }
+
         boolean isExactSearch = argMap.contains(FLAG_EXACT);
         boolean isAnySearch = argMap.contains(FLAG_ANY);
 

--- a/src/main/java/seedu/partyplanet/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/ListCommandParser.java
@@ -4,7 +4,7 @@ import static seedu.partyplanet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 import static seedu.partyplanet.logic.commands.ListCommand.ASC;
 import static seedu.partyplanet.logic.commands.ListCommand.DESC;
 import static seedu.partyplanet.logic.parser.CliSyntax.FLAG_ANY;
-import static seedu.partyplanet.logic.parser.CliSyntax.FLAG_PARTIAL;
+import static seedu.partyplanet.logic.parser.CliSyntax.FLAG_EXACT;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_SORT;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_TAG;
@@ -36,25 +36,25 @@ public class ListCommandParser implements Parser<ListCommand> {
      */
     public ListCommand parse(String args) throws ParseException {
         ArgumentMultimap argMap = ArgumentTokenizer.tokenize(
-                args, PREFIX_NAME, PREFIX_TAG, PREFIX_SORT, FLAG_PARTIAL, FLAG_ANY);
+                args, PREFIX_NAME, PREFIX_TAG, PREFIX_SORT, FLAG_EXACT, FLAG_ANY);
 
-        boolean isPartialSearch = argMap.contains(FLAG_PARTIAL);
+        boolean isExactSearch = argMap.contains(FLAG_EXACT);
         boolean isAnySearch = argMap.contains(FLAG_ANY);
 
         List<Predicate<Person>> predicates = new ArrayList<>();
-        if (isPartialSearch) {
-            for (String name : argMap.getAllValues(PREFIX_NAME)) {
-                predicates.add(new NameContainsKeywordsPredicate(name));
-            }
-            for (String tag : argMap.getAllValues(PREFIX_TAG)) {
-                predicates.add(new TagsContainsTagPredicate(tag));
-            }
-        } else {
+        if (isExactSearch) {
             for (String name : argMap.getAllValues(PREFIX_NAME)) {
                 predicates.add(new NameContainsExactKeywordsPredicate(name));
             }
             for (String tag : argMap.getAllValues(PREFIX_TAG)) {
                 predicates.add(new TagsContainsExactTagPredicate(tag));
+            }
+        } else {
+            for (String name : argMap.getAllValues(PREFIX_NAME)) {
+                predicates.add(new NameContainsKeywordsPredicate(name));
+            }
+            for (String tag : argMap.getAllValues(PREFIX_TAG)) {
+                predicates.add(new TagsContainsTagPredicate(tag));
             }
         }
 

--- a/src/main/java/seedu/partyplanet/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/ListCommandParser.java
@@ -3,19 +3,31 @@ package seedu.partyplanet.logic.parser;
 import static seedu.partyplanet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.partyplanet.logic.commands.ListCommand.ASC;
 import static seedu.partyplanet.logic.commands.ListCommand.DESC;
+import static seedu.partyplanet.logic.parser.CliSyntax.FLAG_ANY;
+import static seedu.partyplanet.logic.parser.CliSyntax.FLAG_PARTIAL;
+import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_SORT;
+import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import seedu.partyplanet.logic.commands.ListCommand;
 import seedu.partyplanet.logic.parser.exceptions.ParseException;
 import seedu.partyplanet.model.person.Person;
+import seedu.partyplanet.model.person.predicates.NameContainsExactKeywordsPredicate;
+import seedu.partyplanet.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.partyplanet.model.person.predicates.TagsContainsExactTagPredicate;
+import seedu.partyplanet.model.person.predicates.TagsContainsTagPredicate;
 
 /**
  * Parses input arguments and creates a new ListCommand object
  */
 public class ListCommandParser implements Parser<ListCommand> {
+
 
     /**
      * Parses the given {@code String} of arguments in the context of the ListCommand
@@ -23,29 +35,50 @@ public class ListCommandParser implements Parser<ListCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ListCommand parse(String args) throws ParseException {
-        ArgumentMultimap argumentMultimap =
-            ArgumentTokenizer.tokenize(args, PREFIX_SORT);
+        ArgumentMultimap argMap = ArgumentTokenizer.tokenize(
+                args, PREFIX_NAME, PREFIX_TAG, PREFIX_SORT, FLAG_PARTIAL, FLAG_ANY);
 
-        Optional<String> sortType = argumentMultimap.getValue(PREFIX_SORT);
+        boolean isPartialSearch = argMap.contains(FLAG_PARTIAL);
+        boolean isAnySearch = argMap.contains(FLAG_ANY);
 
-        if (sortType.isEmpty()) {
-            return new ListCommand(ASC);
+        List<Predicate<Person>> predicates = new ArrayList<>();
+        if (isPartialSearch) {
+            for (String name : argMap.getAllValues(PREFIX_NAME)) {
+                predicates.add(new NameContainsKeywordsPredicate(name));
+            }
+            for (String tag : argMap.getAllValues(PREFIX_TAG)) {
+                predicates.add(new TagsContainsTagPredicate(tag));
+            }
+        } else {
+            for (String name : argMap.getAllValues(PREFIX_NAME)) {
+                predicates.add(new NameContainsExactKeywordsPredicate(name));
+            }
+            for (String tag : argMap.getAllValues(PREFIX_TAG)) {
+                predicates.add(new TagsContainsExactTagPredicate(tag));
+            }
         }
 
-        Comparator<Person> comparator;
+        Comparator<Person> comparator = getSortOrder(argMap.getValue(PREFIX_SORT));
+        return new ListCommand(predicates, isAnySearch, comparator);
+    }
+
+    /**
+     * Returns the sort order depending on sort argument.
+     */
+    private Comparator<Person> getSortOrder(Optional<String> sortType) throws ParseException {
+        if (sortType.isEmpty()) {
+            return ASC;
+        }
+
         switch (sortType.get()) {
         case "asc":
-            comparator = ASC;
-            break;
+            return ASC;
         case "desc":
-            comparator = DESC;
-            break;
+            return DESC;
         default:
             throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
         }
-
-        return new ListCommand(comparator);
     }
 
 }

--- a/src/main/java/seedu/partyplanet/model/person/predicates/NameContainsExactKeywordsPredicate.java
+++ b/src/main/java/seedu/partyplanet/model/person/predicates/NameContainsExactKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.partyplanet.model.person.predicates;
+
+import java.util.function.Predicate;
+
+import seedu.partyplanet.model.person.Person;
+
+/**
+ * Tests that a {@code Person}'s {@code Name} matches all of the keywords given.
+ * Match is case-insensitive to account for fact that two names stored in alternate
+ * case are semantically the same to the user.
+ */
+public class NameContainsExactKeywordsPredicate implements Predicate<Person> {
+    private final String keywords;
+
+    public NameContainsExactKeywordsPredicate(String keywords) {
+        this.keywords = keywords.toLowerCase();
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getName().fullName.toLowerCase().equals(this.keywords);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof NameContainsExactKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((NameContainsExactKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/partyplanet/model/person/predicates/TagsContainsExactTagPredicate.java
+++ b/src/main/java/seedu/partyplanet/model/person/predicates/TagsContainsExactTagPredicate.java
@@ -11,12 +11,12 @@ public class TagsContainsExactTagPredicate implements Predicate<Person> {
     private final String tag;
 
     public TagsContainsExactTagPredicate(String tag) {
-        this.tag = tag;
+        this.tag = tag.toLowerCase();
     }
 
     @Override
     public boolean test(Person person) {
-        return person.getTags().stream().anyMatch(tag -> tag.tagName.equals(this.tag));
+        return person.getTags().stream().anyMatch(tag -> tag.tagName.toLowerCase().equals(this.tag));
     }
 
     @Override

--- a/src/main/java/seedu/partyplanet/model/person/predicates/TagsContainsExactTagPredicate.java
+++ b/src/main/java/seedu/partyplanet/model/person/predicates/TagsContainsExactTagPredicate.java
@@ -16,7 +16,7 @@ public class TagsContainsExactTagPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return person.getTags().stream().anyMatch(tag -> tag.tagName.equalsIgnoreCase(this.tag));
+        return person.getTags().stream().anyMatch(tag -> tag.tagName.equals(this.tag));
     }
 
     @Override

--- a/src/main/java/seedu/partyplanet/model/person/predicates/TagsContainsExactTagPredicate.java
+++ b/src/main/java/seedu/partyplanet/model/person/predicates/TagsContainsExactTagPredicate.java
@@ -1,0 +1,29 @@
+package seedu.partyplanet.model.person.predicates;
+
+import java.util.function.Predicate;
+
+import seedu.partyplanet.model.person.Person;
+
+/**
+ * Tests that a {@code Person}'s {@code Tag}s contains an exact match of the tag given.
+ */
+public class TagsContainsExactTagPredicate implements Predicate<Person> {
+    private final String tag;
+
+    public TagsContainsExactTagPredicate(String tag) {
+        this.tag = tag;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getTags().stream().anyMatch(tag -> tag.tagName.equalsIgnoreCase(this.tag));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagsContainsExactTagPredicate // instanceof handles nulls
+                && tag.equals(((TagsContainsExactTagPredicate) other).tag)); // state check
+    }
+
+}

--- a/src/main/java/seedu/partyplanet/model/person/predicates/TagsContainsTagPredicate.java
+++ b/src/main/java/seedu/partyplanet/model/person/predicates/TagsContainsTagPredicate.java
@@ -11,12 +11,12 @@ public class TagsContainsTagPredicate implements Predicate<Person> {
     private final String tag;
 
     public TagsContainsTagPredicate(String tag) {
-        this.tag = tag;
+        this.tag = tag.toLowerCase();
     }
 
     @Override
     public boolean test(Person person) {
-        return person.getTags().stream().anyMatch(tag -> tag.tagName.contains(this.tag));
+        return person.getTags().stream().anyMatch(tag -> tag.tagName.toLowerCase().contains(this.tag));
     }
 
     @Override

--- a/src/test/java/seedu/partyplanet/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/partyplanet/logic/commands/ListCommandTest.java
@@ -1,10 +1,15 @@
 package seedu.partyplanet.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.partyplanet.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.partyplanet.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.partyplanet.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.partyplanet.logic.commands.ListCommand.ASC;
 import static seedu.partyplanet.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.partyplanet.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Collections;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +17,11 @@ import org.junit.jupiter.api.Test;
 import seedu.partyplanet.model.Model;
 import seedu.partyplanet.model.ModelManager;
 import seedu.partyplanet.model.UserPrefs;
+import seedu.partyplanet.model.person.Person;
+import seedu.partyplanet.model.person.predicates.NameContainsExactKeywordsPredicate;
+import seedu.partyplanet.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.partyplanet.model.person.predicates.TagsContainsExactTagPredicate;
+import seedu.partyplanet.model.person.predicates.TagsContainsTagPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -20,6 +30,12 @@ public class ListCommandTest {
 
     private Model model;
     private Model expectedModel;
+    private final NameContainsKeywordsPredicate predicateKurz = preparePredicate("Kurz");
+    private final NameContainsKeywordsPredicate predicateElle = preparePredicate("Elle");
+    private final NameContainsKeywordsPredicate predicateKunz = preparePredicate("Kunz");
+    private final NameContainsExactKeywordsPredicate predicateExactKurz = prepareExactPredicate("Kurz");
+    private final NameContainsExactKeywordsPredicate predicateExactElle = prepareExactPredicate("Elle");
+    private final NameContainsExactKeywordsPredicate predicateExactKunz = prepareExactPredicate("Kunz");
 
     @BeforeEach
     public void setUp() {
@@ -28,13 +44,139 @@ public class ListCommandTest {
     }
 
     @Test
+    public void equals() {
+        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate("first");
+        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate("second");
+
+        ListCommand listFirstCommand = new ListCommand(firstPredicate);
+        ListCommand listSecondCommand = new ListCommand(secondPredicate);
+
+        // same object -> returns true
+        assertEquals(listFirstCommand, listFirstCommand);
+
+        // same values -> returns true
+        ListCommand listFirstCommandCopy = new ListCommand(firstPredicate);
+        assertEquals(listFirstCommand, listFirstCommandCopy);
+
+        // different person -> returns false
+        assertNotEquals(listFirstCommand, listSecondCommand);
+    }
+
+    @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(ASC), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(ASC), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_allPartialMultipleNames_notFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        Predicate<Person> predicate = predicateKurz.and(predicateElle.and(predicateKunz));
+        ListCommand command = new ListCommand(predicate);
+
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.EMPTY_LIST, model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_anyPartialMultipleNames_found() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        Predicate<Person> predicate = predicateKurz.or(predicateElle.or(predicateKunz));
+        ListCommand command = new ListCommand(predicate);
+
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(3, model.getFilteredPersonList().size());
+    }
+
+    @Test
+    public void execute_allExactMultipleNames_notFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        Predicate<Person> predicate = predicateExactKurz.and(predicateExactElle.and(predicateExactKunz));
+        ListCommand command = new ListCommand(predicate);
+
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.EMPTY_LIST, model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_anyExactMultipleNames_notFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        Predicate<Person> predicate = predicateExactKurz.or(predicateExactElle.or(predicateExactKunz));
+        ListCommand command = new ListCommand(predicate);
+
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.EMPTY_LIST, model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_anyExactMultipleNames_found() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        NameContainsExactKeywordsPredicate predicateExactFullElle = prepareExactPredicate("Elle Meyer");
+        Predicate<Person> predicate = predicateExactKurz.or(predicateExactFullElle.or(predicateExactKunz));
+        ListCommand command = new ListCommand(predicate);
+
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(1, model.getFilteredPersonList().size());
+    }
+
+    @Test
+    public void execute_allPartialWhitespace_multiplePersonsFound() {
+        String expectedMessage = ListCommand.MESSAGE_SUCCESS;
+        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        ListCommand command = new ListCommand(predicate);
+
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(getTypicalAddressBook().getPersonList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_allExactTags_found() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        TagsContainsExactTagPredicate predicateOwesMoney = new TagsContainsExactTagPredicate("owesMoney");
+        TagsContainsExactTagPredicate predicateFriends = new TagsContainsExactTagPredicate("friends");
+        Predicate<Person> predicate = predicateOwesMoney.and(predicateFriends);
+        ListCommand command = new ListCommand(predicate);
+
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(1, model.getFilteredPersonList().size());
+    }
+
+    @Test
+    public void execute_allPartialTagName_found() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3); // Alice, Benson, Daniel
+        TagsContainsTagPredicate predicateTag = new TagsContainsTagPredicate("friend");
+        NameContainsKeywordsPredicate predicateName = new NameContainsKeywordsPredicate("e");
+        Predicate<Person> predicate = predicateTag.and(predicateName);
+        ListCommand command = new ListCommand(predicate);
+
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(3, model.getFilteredPersonList().size());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new NameContainsKeywordsPredicate(userInput);
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsExactKeywordsPredicate}.
+     */
+    private NameContainsExactKeywordsPredicate prepareExactPredicate(String userInput) {
+        return new NameContainsExactKeywordsPredicate(userInput);
     }
 }

--- a/src/test/java/seedu/partyplanet/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/partyplanet/logic/parser/AddressBookParserTest.java
@@ -85,7 +85,6 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
     }
 
     @Test


### PR DESCRIPTION
Adds the specific features specified exactly in the tP document, and documentation updated. Fixes #114.
Detailed description can be found in the user guide.

Syntax to test: `list [--partial] [--any] [-n NAME]... [-t TAG]... [-s SORT_ORDER]`
Features from `find` were partially ported over, including the terminology used for sorting.