### PR TITLE
Add multiple formats for Birthday parsing

### DIFF
--- a/src/main/java/seedu/partyplanet/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/ParserUtil.java
@@ -135,15 +135,15 @@ public class ParserUtil {
     public static Birthday parseBirthday(String birthday) throws ParseException {
         requireNonNull(birthday);
         String trimmedBirthday = birthday.trim();
-        if (birthday == Birthday.EMPTY_BIRTHDAY_STRING) {
+        if (birthday.equals(Birthday.EMPTY_BIRTHDAY_STRING)) {
             return Birthday.EMPTY_BIRTHDAY;
         }
         try {
             return new Birthday(trimmedBirthday);
         } catch (DateTimeException err) { // date in wrong format
             throw new ParseException((Birthday.MESSAGE_CONSTRAINTS));
-        } catch (IllegalArgumentException err) { // birthday year exceeds current year
-            throw new ParseException(Birthday.MESSAGE_YEAR_CONSTRAINTS);
+        } catch (IllegalArgumentException err) { // birthday is in the future
+            throw new ParseException(Birthday.MESSAGE_DATE_CONSTRAINTS);
         }
     }
 

--- a/src/main/java/seedu/partyplanet/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/ParserUtil.java
@@ -135,7 +135,7 @@ public class ParserUtil {
     public static Birthday parseBirthday(String birthday) throws ParseException {
         requireNonNull(birthday);
         String trimmedBirthday = birthday.trim();
-        if (birthday.equals(Birthday.EMPTY_BIRTHDAY_STRING)) {
+        if (birthday == Birthday.EMPTY_BIRTHDAY_STRING) {
             return Birthday.EMPTY_BIRTHDAY;
         }
         try {

--- a/src/main/java/seedu/partyplanet/model/person/Birthday.java
+++ b/src/main/java/seedu/partyplanet/model/person/Birthday.java
@@ -63,7 +63,7 @@ public class Birthday implements Comparable<Birthday> {
      */
     public Birthday(String birthdate) {
         requireNonNull(birthdate);
-        TemporalAccessor date = parseBirthday(birthdate);
+        TemporalAccessor date = parseBirthday(toTitleCase(birthdate));
         hasYear = date instanceof LocalDate;
         if (hasYear) {
             value = ISO_FORMAT.format(date);
@@ -107,6 +107,27 @@ public class Birthday implements Comparable<Birthday> {
             }
         }
         throw new DateTimeException(MESSAGE_CONSTRAINTS);
+    }
+
+    /**
+     * Returns title case for strings.
+     * Required for user inputs in arbitrary case, which DateTimeFormatter does not support parsing for.
+     */
+    private static String toTitleCase(String date) {
+        StringBuilder titleCase = new StringBuilder(date.length());
+        boolean nextCapitalize = true;
+        for (char c: date.toCharArray()) {
+            if (!Character.isLetter(c)) {
+                nextCapitalize = true;
+            } else if (nextCapitalize) {
+                c = Character.toUpperCase(c);
+                nextCapitalize = false;
+            } else {
+                c = Character.toLowerCase(c);
+            }
+            titleCase.append(c);
+        }
+        return titleCase.toString();
     }
 
     /**

--- a/src/main/java/seedu/partyplanet/model/person/Birthday.java
+++ b/src/main/java/seedu/partyplanet/model/person/Birthday.java
@@ -5,32 +5,76 @@ import static seedu.partyplanet.commons.util.AppUtil.checkArgument;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
+import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 
 /** Represents a Person's birthday in PartyPlanet.
  * Guarantees: immutable; is always valid.
  */
-public class Birthday {
+public class Birthday implements Comparable<Birthday> {
 
-    public static final String MESSAGE_CONSTRAINTS = "Birthday must be in the format yyyy-mm-dd";
-    public static final String MESSAGE_YEAR_CONSTRAINTS =
-            String.format("Year should not exceed %d", LocalDate.now().getYear());
-
+    public static final String MESSAGE_CONSTRAINTS = "Birthdays should be in one of the following formats:\n"
+            + "    - yyyy-mm-dd (ISO format)\n"
+            + "    - dd.mm.yyyy\n"
+            + "    - dd/mm/yyyy\n"
+            + "    - dd mmm yyyy\n"
+            + "    - mmm dd yyyy";
+    public static final String MESSAGE_DATE_CONSTRAINTS = "Birthday should not be a date in the future";
     public static final String EMPTY_BIRTHDAY_STRING = "";
     public static final Birthday EMPTY_BIRTHDAY = new Birthday();
 
+    private static final DateTimeFormatter[] VALID_FORMATS = new DateTimeFormatter[] {
+            DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+            DateTimeFormatter.ofPattern("d.M.yyyy"),
+            DateTimeFormatter.ofPattern("d/M/yyyy"),
+            DateTimeFormatter.ofPattern("d MMM yyyy"),
+            DateTimeFormatter.ofPattern("d MMMM yyyy"),
+            DateTimeFormatter.ofPattern("MMM d yyyy"),
+            DateTimeFormatter.ofPattern("MMMM d yyyy"),
+    };
+    private static final DateTimeFormatter[] VALID_FORMATS_WITHOUT_YEAR = new DateTimeFormatter[] {
+            DateTimeFormatter.ofPattern("--MM-dd"),
+            DateTimeFormatter.ofPattern("d/M"),
+            DateTimeFormatter.ofPattern("d MMM"),
+            DateTimeFormatter.ofPattern("d MMMM"),
+            DateTimeFormatter.ofPattern("MMM d"),
+            DateTimeFormatter.ofPattern("MMMM d"),
+    };
+    private static final DateTimeFormatter ISO_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter ISO_FORMAT_WITHOUT_YEAR = DateTimeFormatter.ofPattern("--MM-dd");
+    private static final DateTimeFormatter READABLE_FORMAT = DateTimeFormatter.ofPattern("d MMM yyyy");
+    private static final DateTimeFormatter READABLE_FORMAT_WITHOUT_YEAR = DateTimeFormatter.ofPattern("d MMM");
+
+    /** In "dd mmm yyyy" formatted string for human-readable display */
+    public final String displayValue;
+    /** In ISO-8601 format for easy comparison */
     public final String value;
+    private int month; // implemented for quick retrieval
+    private boolean hasYear;
     private boolean isEmpty = false;
 
     /**
      * Constructs a {@code Birthday}.
+     * Birthdate should not be in the future, and can optionally contain a year.
+     * Some invalid dates are mapped to the nearest valid date, e.g. 29 Feb 2021 -> 28 Feb 2021.
      *
      * @param birthdate A valid birthdate.
      */
     public Birthday(String birthdate) {
         requireNonNull(birthdate);
-        isValidBirthday(birthdate);
-        checkArgument(isValidBirthdayYear(birthdate), MESSAGE_YEAR_CONSTRAINTS);
-        value = birthdate;
+        TemporalAccessor date = parseBirthday(birthdate);
+        hasYear = date instanceof LocalDate;
+        if (hasYear) {
+            value = ISO_FORMAT.format(date);
+            displayValue = READABLE_FORMAT.format(date);
+            month = ((LocalDate) date).getMonthValue();
+        } else {
+            value = ISO_FORMAT_WITHOUT_YEAR.format(date);
+            displayValue = READABLE_FORMAT_WITHOUT_YEAR.format(date);
+            month = ((MonthDay) date).getMonthValue();
+        }
+        checkArgument(isValidBirthdayDate(value), MESSAGE_DATE_CONSTRAINTS);
     }
 
     /**
@@ -38,7 +82,31 @@ public class Birthday {
      */
     public Birthday() {
         value = EMPTY_BIRTHDAY_STRING;
+        displayValue = EMPTY_BIRTHDAY_STRING;
         isEmpty = true;
+    }
+
+    /**
+     * Attempts to match {@code birthdate} to any parsing rule.
+     * If valid, a LocalDate or MonthDay is returned depending on whether a year exists,
+     * otherwise a DateTimeException will be thrown.
+     */
+    public static TemporalAccessor parseBirthday(String birthdate) throws DateTimeException {
+        for (DateTimeFormatter dateFormat: VALID_FORMATS) {
+            try {
+                return LocalDate.parse(birthdate, dateFormat);
+            } catch (DateTimeException e) {
+                continue;
+            }
+        }
+        for (DateTimeFormatter dateFormat: VALID_FORMATS_WITHOUT_YEAR) {
+            try {
+                return MonthDay.parse(birthdate, dateFormat);
+            } catch (DateTimeException e) {
+                continue;
+            }
+        }
+        throw new DateTimeException(MESSAGE_CONSTRAINTS);
     }
 
     /**
@@ -49,37 +117,88 @@ public class Birthday {
     }
 
     /**
-     * Returns true if a given birthday string has a valid year.
+     * Returns true if a given birthday string is a valid date not in the future.
      */
-    public static boolean isValidBirthdayYear(String test) {
-        return Integer.parseInt(test.split("-")[0]) <= LocalDate.now().getYear();
+    public static boolean isValidBirthdayDate(String test) {
+        return isValidBirthdayDate(test, LocalDate.now());
     }
 
     /**
-     * Throws an error if a given string is an invalid birthday.
+     * Returns true if a given birthday string is a valid date not after {@code reference}.
+     * Exposes {@reference} date as a parameter for unit testing.
+     * Note: Dates without years which are parsed successfully are always considered valid.
      */
-    public static void isValidBirthday(String test) {
+    public static boolean isValidBirthdayDate(String test, LocalDate reference) {
+        String referenceDate = ISO_FORMAT.format(reference);
+        TemporalAccessor date = parseBirthday(test);
+        String testDate = (date instanceof LocalDate ? ISO_FORMAT : ISO_FORMAT_WITHOUT_YEAR).format(date);
+        return testDate.compareTo(referenceDate) <= 0;
+    }
+
+    /**
+     * Returns true if a given string is a valid birthday, otherwise false.
+     * Implemented for unit testing.
+     */
+    public static boolean isValidBirthday(String test) {
         try {
-            LocalDate.parse(test);
-        } catch (DateTimeException err) {
-            throw new DateTimeException(MESSAGE_CONSTRAINTS);
+            parseBirthday(test);
+            return true;
+        } catch (DateTimeException e) {
+            return false;
         }
+    }
+
+    /**
+     * Returns the month value of the birthday, in the range [1-12].
+     * Required for feature to filter contact birthdays by month.
+     */
+    public int getMonth() {
+        if (isEmpty) {
+            throw new IllegalArgumentException("Birthday is empty");
+        }
+        return month;
+    }
+
+    @Override
+    public int compareTo(Birthday other) {
+        return getMonthDayString().compareTo(other.getMonthDayString());
+    }
+
+    /**
+     * Returns month and day as "mm-dd" in ISO format.
+     * For easier comparison between Birthday objects.
+     *
+     * Note: Can consider refactoring this to rely on (month,day) integer pairs instead.
+     */
+    private String getMonthDayString() {
+        if (isEmpty) {
+            throw new IllegalArgumentException("Birthday is empty");
+        }
+        return hasYear ? value.substring(5) : value.substring(2);
     }
 
     @Override
     public String toString() {
-        return value;
+        return displayValue;
     }
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Birthday // instanceof handles nulls
-                && value.equals(((Birthday) other).value)); // state check
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof Birthday)) {
+            return false;
+        }
+        if (isEmpty == isEmptyBirthday((Birthday) other)) {
+            return true;
+        }
+        return value.equals(((Birthday) other).value);
     }
 
     @Override
     public int hashCode() {
         return value.hashCode();
     }
+
 }

--- a/src/main/java/seedu/partyplanet/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/partyplanet/storage/JsonAdaptedPerson.java
@@ -125,7 +125,7 @@ class JsonAdaptedPerson {
             } catch (DateTimeException err) { // date in wrong format
                 throw new IllegalValueException(Birthday.MESSAGE_CONSTRAINTS);
             } catch (IllegalArgumentException err) { // birthday year exceeds current year
-                throw new IllegalValueException(Birthday.MESSAGE_YEAR_CONSTRAINTS);
+                throw new IllegalValueException(Birthday.MESSAGE_DATE_CONSTRAINTS);
             }
         }
 

--- a/src/main/java/seedu/partyplanet/ui/PersonCard.java
+++ b/src/main/java/seedu/partyplanet/ui/PersonCard.java
@@ -69,7 +69,7 @@ public class PersonCard extends UiPart<Region> {
             email.setText(person.getEmail().value);
         }
         if (!Birthday.isEmptyBirthday(person.getBirthday())) {
-            birthday.setText(person.getBirthday().value);
+            birthday.setText(person.getBirthday().displayValue);
         }
         if (!Remark.isEmptyRemark(person.getRemark())) {
             remark.setText(person.getRemark().value);

--- a/src/test/java/seedu/partyplanet/model/person/BirthdayTest.java
+++ b/src/test/java/seedu/partyplanet/model/person/BirthdayTest.java
@@ -1,0 +1,121 @@
+package seedu.partyplanet.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.partyplanet.testutil.Assert.assertThrows;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.MonthDay;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+public class BirthdayTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Birthday(null));
+    }
+
+    @Test
+    public void constructor_invalidBirthday_throwsDateTimeException() {
+        String invalidBirthday = "";
+        assertThrows(DateTimeException.class, () -> new Birthday(invalidBirthday));
+    }
+
+    @Test
+    public void isValidBirthday_invalidBirthdays() {
+        // null birthdays
+        assertThrows(NullPointerException.class, () -> Birthday.isValidBirthday(null));
+
+        // invalid birthdays
+        assertFalse(Birthday.isValidBirthday("")); // empty string
+        assertFalse(Birthday.isValidBirthday(" ")); // spaces only
+        assertFalse(Birthday.isValidBirthday("91")); // none match
+        assertFalse(Birthday.isValidBirthday("2021 Feb 20")); // unsupported format
+        assertFalse(Birthday.isValidBirthday("20Feb2021")); // unsupported format
+    }
+
+    @Test
+    public void isValidBirthday_validWithYears() {
+        String[] validInputs = new String[]{
+            "2021-02-03",
+            "3.2.2021",
+            "3/2/2021",
+            "3 Feb 2021",
+            "3 February 2021",
+            "Feb 3 2021",
+            "February 3 2021",
+        };
+        for (String validInput: validInputs) {
+            assertTrue(Birthday.isValidBirthday(validInput));
+        }
+        assertEquals(1, Arrays.stream(validInputs)
+                .map(Birthday::parseBirthday)
+                .map(x -> (LocalDate) x)
+                .distinct()
+                .count());
+    }
+
+    @Test
+    public void isValidBirthday_validWithoutYears() {
+        String[] validInputs = new String[]{
+            "--02-03",
+            "3/2",
+            "3 Feb",
+            "3 February",
+            "Feb 3",
+            "February 3",
+        };
+        for (String validInput: validInputs) {
+            assertTrue(Birthday.isValidBirthday(validInput));
+        }
+        assertEquals(1, Arrays.stream(validInputs)
+                .map(Birthday::parseBirthday)
+                .map(x -> (MonthDay) x)
+                .distinct()
+                .count());
+    }
+
+    @Test
+    public void isValidBirthdayDate() {
+        LocalDate referenceDate = LocalDate.of(2021, 6, 6);
+
+        // MonthDay is always valid
+        assertTrue(Birthday.isValidBirthdayDate("--02-03", referenceDate));
+        assertTrue(Birthday.isValidBirthdayDate("--06-06", referenceDate));
+        assertTrue(Birthday.isValidBirthdayDate("--12-12", referenceDate));
+
+        // LocalDate must be before reference
+        assertTrue(Birthday.isValidBirthdayDate("2021-06-05", referenceDate));
+        assertTrue(Birthday.isValidBirthdayDate("2021-06-06", referenceDate));
+        assertFalse(Birthday.isValidBirthdayDate("2021-06-07", referenceDate));
+    }
+
+    @Test
+    public void compareTo() {
+        // Same year
+        Birthday localDate0606 = new Birthday("2020-06-06");
+        Birthday monthDay0606 = new Birthday("--06-06");
+        Birthday monthDay0607 = new Birthday("--06-07");
+        Birthday localDate0608 = new Birthday("2020-06-08");
+
+        // Different year
+        Birthday localDatePrevYear = new Birthday("2019-08-13");
+
+        // Same date
+        assertEquals(0, localDate0606.compareTo(localDate0606));
+        assertEquals(0, monthDay0606.compareTo(monthDay0606));
+        assertEquals(0, localDate0606.compareTo(monthDay0606));
+
+        // Different date
+        assertTrue(localDate0606.compareTo(monthDay0607) < 0);
+        assertTrue(monthDay0606.compareTo(monthDay0607) < 0);
+        assertTrue(localDate0606.compareTo(localDate0608) < 0);
+        assertTrue(monthDay0607.compareTo(localDate0608) < 0);
+        assertTrue(localDate0608.compareTo(localDatePrevYear) < 0);
+        assertTrue(localDatePrevYear.compareTo(localDate0606) > 0);
+    }
+}


### PR DESCRIPTION
To support dates with or without years, and comparison between such dates. Fixes #91.
The list of allowed patterns are stated in the unit tests:

https://github.com/pyuxiang/tp/blob/1f059df0e26bac1f2d0629810367bb86b6c38795/src/test/java/seedu/partyplanet/model/person/BirthdayTest.java#L41-L80


### Algorithm notes

To perform parsing of dates, we rely on `MonthDay` and `LocalDate` parsers to ensure dates are valid, and specifying using `DateTimeFormatter` increases the consistency of the date specifications.

Creating a `Birthday` object is twice as expensive due to running the birthday parser twice, once in the constructor directly, and another in the static `isValidBirthdayDate`. The latter is important for unit testing as well as parsing during loading of saved data. Briefly considered creating another similar birthday date validity checker, but figured the runtime cost of double parsing isn't too high to warrant optimization as opposed to lowered readability.




### Field and method notes

The use of storing dates as a ISO-8601 string in `Birthday.value` is two-fold: (1) easy to compare, and (2) easy to store.

The `month` attribute is initialized solely for efficiency, in the event we want to implement a feature to list out contacts by a particular month(s).

A date comparison is also implemented, whose natural order is in ascending `(month, day)` pairs, ignoring the year. This will be important for possible upcoming features to sort contacts by date - a possible additional feature includes a similar comparator, but takes in an additional reference date to sort in increasing number of days away from this reference.


### Required follow-up

- Update user guide to reflect available date specification format. Will probably open as an issue to settle in later iterations.