### PR TITLE
Allow delete to ignore duplicate indices

### DIFF
--- a/src/main/java/seedu/partyplanet/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/DeleteCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.partyplanet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -62,10 +63,15 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     private DeleteContactCommand createDeleteContactCommand(String args) throws ParseException {
         String[] strIndexes = args.split("\\s+");
         List<Index> indexes = new ArrayList<>();
+        Set<Integer> intIndices = new HashSet<>();
 
         for (String s : strIndexes) {
             Index index = ParserUtil.parseIndex(s);
+            if (intIndices.contains(index.getZeroBased())) {
+                continue;
+            }
             indexes.add(index);
+            intIndices.add(index.getZeroBased());
         }
 
         return new DeleteContactCommand(indexes);

--- a/src/main/java/seedu/partyplanet/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/DeleteCommandParser.java
@@ -4,7 +4,6 @@ import static seedu.partyplanet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -63,15 +62,12 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     private DeleteContactCommand createDeleteContactCommand(String args) throws ParseException {
         String[] strIndexes = args.split("\\s+");
         List<Index> indexes = new ArrayList<>();
-        Set<Integer> intIndices = new HashSet<>();
 
         for (String s : strIndexes) {
             Index index = ParserUtil.parseIndex(s);
-            if (intIndices.contains(index.getZeroBased())) {
-                continue;
+            if (!indexes.contains(index)) {
+                indexes.add(index);
             }
-            indexes.add(index);
-            intIndices.add(index.getZeroBased());
         }
 
         return new DeleteContactCommand(indexes);


### PR DESCRIPTION
Fixes #127, using a set to identify duplicate indices.
Note: Cannot apply directly with `Index` since `HashSet` performs referential instead of equality check.