### PR TITLE
Refactor Date + Implement sort by upcoming

### DIFF
--- a/src/main/java/seedu/partyplanet/logic/commands/EListCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/EListCommand.java
@@ -8,10 +8,7 @@ import java.util.function.Predicate;
 
 import seedu.partyplanet.commons.core.Messages;
 import seedu.partyplanet.model.Model;
-import seedu.partyplanet.model.date.Date;
 import seedu.partyplanet.model.event.Event;
-import seedu.partyplanet.model.event.EventDate;
-import seedu.partyplanet.model.person.Person;
 
 /**
  * Lists all events in PartyPlanet to the user.
@@ -31,19 +28,18 @@ public class EListCommand extends Command {
 
     public static final Comparator<Event> SORT_NAME = Comparator.comparing(x -> x.getName().fullName);
     public static final Comparator<Event> SORT_EVENTDATE = Comparator.comparing(Event::getEventDate);
-    public static final Comparator<Event> SORT_EVENTDATE_UPCOMING =
-            (Event x, Event y) -> {
-                // Sort done events at the end
-                if (x.isDone() && !y.isDone()) {
-                    return 1;
-                }
-                if (!x.isDone() && y.isDone()) {
-                    return -1;
-                }
-                Long xDaysLeft = x.getEventDate().getDaysLeft();
-                Long yDaysLeft = y.getEventDate().getDaysLeft();
-                return xDaysLeft.compareTo(yDaysLeft);
-            };
+    public static final Comparator<Event> SORT_EVENTDATE_UPCOMING = (Event x, Event y) -> {
+        // Sort done events at the end
+        if (x.isDone() && !y.isDone()) {
+            return 1;
+        }
+        if (!x.isDone() && y.isDone()) {
+            return -1;
+        }
+        Long xDaysLeft = x.getEventDate().getDaysLeft();
+        Long yDaysLeft = y.getEventDate().getDaysLeft();
+        return xDaysLeft.compareTo(yDaysLeft);
+    };
 
     private final Comparator<Event> comparator;
     private final Predicate<Event> predicate;

--- a/src/main/java/seedu/partyplanet/logic/commands/EListCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/EListCommand.java
@@ -8,7 +8,10 @@ import java.util.function.Predicate;
 
 import seedu.partyplanet.commons.core.Messages;
 import seedu.partyplanet.model.Model;
+import seedu.partyplanet.model.date.Date;
 import seedu.partyplanet.model.event.Event;
+import seedu.partyplanet.model.event.EventDate;
+import seedu.partyplanet.model.person.Person;
 
 /**
  * Lists all events in PartyPlanet to the user.
@@ -28,6 +31,19 @@ public class EListCommand extends Command {
 
     public static final Comparator<Event> SORT_NAME = Comparator.comparing(x -> x.getName().fullName);
     public static final Comparator<Event> SORT_EVENTDATE = Comparator.comparing(Event::getEventDate);
+    public static final Comparator<Event> SORT_EVENTDATE_UPCOMING =
+            (Event x, Event y) -> {
+                // Sort done events at the end
+                if (x.isDone() && !y.isDone()) {
+                    return 1;
+                }
+                if (!x.isDone() && y.isDone()) {
+                    return -1;
+                }
+                Long xDaysLeft = x.getEventDate().getDaysLeft();
+                Long yDaysLeft = y.getEventDate().getDaysLeft();
+                return xDaysLeft.compareTo(yDaysLeft);
+            };
 
     private final Comparator<Event> comparator;
     private final Predicate<Event> predicate;

--- a/src/main/java/seedu/partyplanet/logic/commands/EListCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/EListCommand.java
@@ -32,15 +32,23 @@ public class EListCommand extends Command {
     public static final Comparator<Event> SORT_NAME = Comparator.comparing(x -> x.getName().fullName);
     public static final Comparator<Event> SORT_EVENTDATE = Comparator.comparing(Event::getEventDate);
     public static final Comparator<Event> SORT_EVENTDATE_UPCOMING = (Event x, Event y) -> {
-        // Sort done events at the end
-        if (x.isDone() && !y.isDone()) {
-            return 1;
-        }
-        if (!x.isDone() && y.isDone()) {
-            return -1;
-        }
         Long xDaysLeft = x.getEventDate().getDaysLeft();
         Long yDaysLeft = y.getEventDate().getDaysLeft();
+
+        // For pairs of events that are upcoming and not done, sort by date
+        if (!x.isDone() && !y.isDone() && xDaysLeft >= 0 && yDaysLeft >= 0) {
+            return xDaysLeft.compareTo(yDaysLeft);
+        }
+
+        // If event is upcoming and not done, sort in front
+        if (!x.isDone() && xDaysLeft >= 0) {
+            return -1;
+        }
+        if (!y.isDone() && yDaysLeft >= 0) {
+            return 1;
+        }
+
+        // Sort the rest of events by date
         return xDaysLeft.compareTo(yDaysLeft);
     };
 

--- a/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
@@ -8,6 +8,7 @@ import java.util.function.Predicate;
 
 import seedu.partyplanet.commons.core.Messages;
 import seedu.partyplanet.model.Model;
+import seedu.partyplanet.model.date.Date;
 import seedu.partyplanet.model.person.Person;
 
 /**
@@ -31,6 +32,8 @@ public class ListCommand extends Command {
 
     public static final Comparator<Person> SORT_NAME = Comparator.comparing(x -> x.getName().fullName);
     public static final Comparator<Person> SORT_BIRTHDAY = Comparator.comparing(Person::getBirthday);
+    public static final Comparator<Person> SORT_BIRTHDAY_UPCOMING =
+            Comparator.comparing(x -> Date.getDateWithoutYear(x.getBirthday()));
 
     private final Comparator<Person> comparator;
     private final Predicate<Person> predicate;

--- a/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/ListCommand.java
@@ -31,9 +31,10 @@ public class ListCommand extends Command {
             COMMAND_WORD + " [--exact] [--any] [-n NAME]... [-t TAG]... [-s SORT_FIELD] [-o SORT_ORDER]";
 
     public static final Comparator<Person> SORT_NAME = Comparator.comparing(x -> x.getName().fullName);
-    public static final Comparator<Person> SORT_BIRTHDAY = Comparator.comparing(Person::getBirthday);
-    public static final Comparator<Person> SORT_BIRTHDAY_UPCOMING =
+    public static final Comparator<Person> SORT_BIRTHDAY =
             Comparator.comparing(x -> Date.getDateWithoutYear(x.getBirthday()));
+    public static final Comparator<Person> SORT_BIRTHDAY_UPCOMING =
+            Comparator.comparing(x -> x.getBirthday().getDaysLeft(true));
 
     private final Comparator<Person> comparator;
     private final Predicate<Person> predicate;

--- a/src/main/java/seedu/partyplanet/logic/parser/EListCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/EListCommandParser.java
@@ -4,7 +4,6 @@ import static seedu.partyplanet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 import static seedu.partyplanet.logic.commands.EListCommand.SORT_EVENTDATE;
 import static seedu.partyplanet.logic.commands.EListCommand.SORT_EVENTDATE_UPCOMING;
 import static seedu.partyplanet.logic.commands.EListCommand.SORT_NAME;
-import static seedu.partyplanet.logic.commands.ListCommand.SORT_BIRTHDAY_UPCOMING;
 import static seedu.partyplanet.logic.parser.CliSyntax.FLAG_ANY;
 import static seedu.partyplanet.logic.parser.CliSyntax.FLAG_EXACT;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_NAME;

--- a/src/main/java/seedu/partyplanet/logic/parser/EListCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/EListCommandParser.java
@@ -2,7 +2,9 @@ package seedu.partyplanet.logic.parser;
 
 import static seedu.partyplanet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.partyplanet.logic.commands.EListCommand.SORT_EVENTDATE;
+import static seedu.partyplanet.logic.commands.EListCommand.SORT_EVENTDATE_UPCOMING;
 import static seedu.partyplanet.logic.commands.EListCommand.SORT_NAME;
+import static seedu.partyplanet.logic.commands.ListCommand.SORT_BIRTHDAY_UPCOMING;
 import static seedu.partyplanet.logic.parser.CliSyntax.FLAG_ANY;
 import static seedu.partyplanet.logic.parser.CliSyntax.FLAG_EXACT;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_NAME;
@@ -127,6 +129,9 @@ public class EListCommandParser implements Parser<EListCommand> {
             case "d": // fallthrough
             case "date":
                 return SORT_EVENTDATE;
+            case "u": // fallthrough
+            case "upcoming":
+                return SORT_EVENTDATE_UPCOMING;
             default:
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, EListCommand.MESSAGE_USAGE));
@@ -140,7 +145,7 @@ public class EListCommandParser implements Parser<EListCommand> {
     private Comparator<Event> applySortDirection(
             Comparator<Event> comparator, ArgumentMultimap argMap) throws ParseException {
         Optional<String> orderType = argMap.getValue(PREFIX_ORDER);
-        if (orderType.isEmpty()) {
+        if (orderType.isEmpty() || comparator == SORT_EVENTDATE_UPCOMING) {
             return comparator; // default
         } else {
             switch (orderType.get().toLowerCase()) {

--- a/src/main/java/seedu/partyplanet/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/ListCommandParser.java
@@ -2,6 +2,7 @@ package seedu.partyplanet.logic.parser;
 
 import static seedu.partyplanet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.partyplanet.logic.commands.ListCommand.SORT_BIRTHDAY;
+import static seedu.partyplanet.logic.commands.ListCommand.SORT_BIRTHDAY_UPCOMING;
 import static seedu.partyplanet.logic.commands.ListCommand.SORT_NAME;
 import static seedu.partyplanet.logic.parser.CliSyntax.FLAG_ANY;
 import static seedu.partyplanet.logic.parser.CliSyntax.FLAG_EXACT;
@@ -127,6 +128,9 @@ public class ListCommandParser implements Parser<ListCommand> {
             case "b": // fallthrough
             case "birthday":
                 return SORT_BIRTHDAY;
+            case "u": // fallthrough
+            case "upcoming":
+                return SORT_BIRTHDAY_UPCOMING;
             default:
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
@@ -140,7 +144,7 @@ public class ListCommandParser implements Parser<ListCommand> {
     private Comparator<Person> applySortDirection(
             Comparator<Person> comparator, ArgumentMultimap argMap) throws ParseException {
         Optional<String> orderType = argMap.getValue(PREFIX_ORDER);
-        if (orderType.isEmpty()) {
+        if (orderType.isEmpty() || comparator == SORT_BIRTHDAY_UPCOMING) {
             return comparator; // default
         } else {
             switch (orderType.get().toLowerCase()) {

--- a/src/main/java/seedu/partyplanet/model/date/Date.java
+++ b/src/main/java/seedu/partyplanet/model/date/Date.java
@@ -7,7 +7,7 @@ import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.MonthDay;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAccessor;
+import java.time.temporal.ChronoUnit;
 
 
 /** Represents a Date in PartyPlanet.
@@ -22,6 +22,9 @@ public class Date implements Comparable<Date> {
 
     public static final String MESSAGE_YEAR_CONSTRAINTS = "A year is required for the input\n";
     public static final String EMPTY_DATE_STRING = "";
+
+    private static int MIN_YEAR = 0;
+    private static int NON_YEAR = -1;
 
     protected static final DateTimeFormatter[] VALID_FORMATS = new DateTimeFormatter[] {
             DateTimeFormatter.ofPattern("yyyy-MM-dd"),
@@ -46,62 +49,70 @@ public class Date implements Comparable<Date> {
     protected static final DateTimeFormatter READABLE_FORMAT_WITHOUT_YEAR = DateTimeFormatter.ofPattern("d MMM");
 
     /** In "dd mmm yyyy" formatted string for human-readable display */
-    public final String displayValue;
-    /** In ISO-8601 format for easy comparison */
     public final String value;
-    protected int month; // implemented for quick retrieval
-    protected boolean hasYear;
+    protected LocalDate date;
     protected boolean isEmpty = false;
-
-    /**
-     * Constructs a {@code Date}.
-     * Date  can optionally contain a year.
-     * Some invalid dates are mapped to the nearest valid date, e.g. 29 Feb 2021 -> 28 Feb 2021.
-     *
-     * @param inputDate A valid date.
-     */
-    public Date(String inputDate, boolean requiresYear) {
-        requireNonNull(inputDate);
-        TemporalAccessor date = parseDate(toTitleCase(inputDate));
-        hasYear = date instanceof LocalDate;
-        if (hasYear) {
-            value = ISO_FORMAT.format(date);
-            displayValue = READABLE_FORMAT.format(date);
-            month = ((LocalDate) date).getMonthValue();
-        } else {
-            checkArgument(!requiresYear, MESSAGE_YEAR_CONSTRAINTS);
-            value = ISO_FORMAT_WITHOUT_YEAR.format(date);
-            displayValue = READABLE_FORMAT_WITHOUT_YEAR.format(date);
-            month = ((MonthDay) date).getMonthValue();
-        }
-        checkArgument(isValidDate(value), MESSAGE_CONSTRAINTS);
-    }
 
     /**
      * Constructs an empty date.
      */
     public Date() {
         value = EMPTY_DATE_STRING;
-        displayValue = EMPTY_DATE_STRING;
         isEmpty = true;
     }
 
     /**
-     * Attempts to match {@code date} to any parsing rule.
-     * If valid, a LocalDate or MonthDay is returned depending on whether a year exists,
-     * otherwise a DateTimeException will be thrown.
+     * Constructs a {@code Date}.
+     * Date can optionally contain a year.
+     * Some invalid dates are mapped to the nearest valid date, e.g. 29 Feb 2021 -> 28 Feb 2021.
+     *
+     * @param inputDate A valid date string.
      */
-    public static TemporalAccessor parseDate(String date) throws DateTimeException {
+    public Date(String inputDate, boolean requiresYear) {
+        requireNonNull(inputDate);
+        checkArgument(isValidDate(inputDate), MESSAGE_CONSTRAINTS);
+        LocalDate date = parseDate(inputDate);
+        if (date.getYear() == NON_YEAR) {
+            checkArgument(!requiresYear, MESSAGE_YEAR_CONSTRAINTS);
+            value = READABLE_FORMAT_WITHOUT_YEAR.format(date);
+        } else {
+            value = READABLE_FORMAT.format(date);
+        }
+    }
+
+    /**
+     * Returns true if a given string is a valid date, otherwise false.
+     * Implemented for unit testing.
+     */
+    public static boolean isValidDate(String test) {
+        try {
+            parseDate(test);
+            return true;
+        } catch (DateTimeException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to match {@code date} to any parsing rule.
+     * If valid, a LocalDate is returned, otherwise a DateTimeException will be thrown.
+     */
+    public static LocalDate parseDate(String date) throws DateTimeException {
+        date = toTitleCase(date);
         for (DateTimeFormatter dateFormat: VALID_FORMATS) {
             try {
-                return LocalDate.parse(date, dateFormat);
+                LocalDate parsedDate = LocalDate.parse(date, dateFormat);
+                if (parsedDate.getYear() < MIN_YEAR) {
+                    continue;
+                }
+                return parsedDate;
             } catch (DateTimeException e) {
                 continue;
             }
         }
         for (DateTimeFormatter dateFormat: VALID_FORMATS_WITHOUT_YEAR) {
             try {
-                return MonthDay.parse(date, dateFormat);
+                return MonthDay.parse(date, dateFormat).atYear(NON_YEAR);
             } catch (DateTimeException e) {
                 continue;
             }
@@ -113,7 +124,7 @@ public class Date implements Comparable<Date> {
      * Returns title case for strings.
      * Required for user inputs in arbitrary case, which DateTimeFormatter does not support parsing for.
      */
-    protected static String toTitleCase(String date) {
+    private static String toTitleCase(String date) {
         StringBuilder titleCase = new StringBuilder(date.length());
         boolean nextCapitalize = true;
         for (char c: date.toCharArray()) {
@@ -137,77 +148,71 @@ public class Date implements Comparable<Date> {
         return date.isEmpty;
     }
 
-
     /**
-     * Returns true if a given date string is a valid date not in the future.
+     * Returns the number of days left till the date, relative to current date.
      */
-    public static boolean isFuture(String test) {
-        assert isValidDate(test);
-        return isFuture(test, LocalDate.now());
+    public long getDaysLeft() {
+        return getDaysLeft(false);
     }
 
     /**
-     * Returns true if a given date string is a valid date not after {@code reference}.
-     * Exposes {@reference} date as a parameter for unit testing.
-     * Note: Dates without years which are parsed successfully are always considered not from the future.
+     * Returns the number of days left till the date, relative to current date.
+     * If {@code ignoreYear} is set to 'true', the number of days to the next month and day
+     * is returned, i.e. the date is treated as a yearly event.
      */
-    public static boolean isFuture(String test, LocalDate reference) {
-        assert isValidDate(test);
-        String referenceDate = ISO_FORMAT.format(reference);
-        TemporalAccessor date = parseDate(test);
-        if (date instanceof LocalDate) {
-            String testDate = ISO_FORMAT.format(date);
-            return testDate.compareTo(referenceDate) > 0;
-        } else {
-            return false;
+    public long getDaysLeft(boolean ignoreYear) {
+        return getDaysLeft(ignoreYear, LocalDate.now());
+    }
+
+    /**
+     * Returns the number of days left till the date, relative to {@code reference}.
+     * If {@code ignoreYear} is set to 'true', the number of days to the next month and day
+     * is returned, i.e. the date is treated as a yearly event.
+     */
+    public long getDaysLeft(boolean ignoreYear, LocalDate reference) {
+        if (!ignoreYear) {
+            return ChronoUnit.DAYS.between(reference, date);
         }
-    }
-
-    /**
-     * Returns true if a given string is a valid date, otherwise false.
-     * Implemented for unit testing.
-     */
-    public static boolean isValidDate(String test) {
-        try {
-            parseDate(test);
-            return true;
-        } catch (DateTimeException e) {
-            return false;
+        LocalDate upcomingDate = date.withYear(reference.getYear());
+        if (reference.isAfter(upcomingDate)) {
+            upcomingDate = date.withYear(reference.getYear() + 1);
         }
+        return ChronoUnit.DAYS.between(reference, upcomingDate);
     }
 
     /**
-     * Returns the month value of the date, in the range [1-12].
+     * Returns the month value of the date, in the range [1-12] if the month exists,
+     * otherwise 0 is returned if no month is available.
      * Required for feature to filter contact dates by month.
      */
     public int getMonth() {
         if (isEmpty) {
-            throw new IllegalArgumentException("Date is empty");
+            return 0;
         }
-        return month;
-    }
-
-    @Override
-    public int compareTo(Date other) {
-        return value.compareTo(other.value);
+        return date.getMonthValue();
     }
 
     /**
-     * Returns month and day as "mm-dd" in ISO format.
-     * For easier comparison between Date objects.
-     *
-     * Note: Can consider refactoring this to rely on (month,day) integer pairs instead.
+     * Returns 0 if equal, otherwise positive (negative) integer if date is earlier (later).
+     * Empty dates are always treated as later dates.
      */
-    public String getMonthDayString() {
-        if (isEmpty) {
-            return "";
+    @Override
+    public int compareTo(Date other) {
+        if (isEmpty && isEmptyDate(other)) {
+            return 0;
         }
-        return hasYear ? value.substring(5) : value.substring(2);
+        if (isEmpty) {
+            return 1;
+        }
+        if (isEmptyDate(other)) {
+            return -1;
+        }
+        return date.compareTo(other.date);
     }
 
     @Override
     public String toString() {
-        return displayValue;
+        return value;
     }
 
     @Override

--- a/src/main/java/seedu/partyplanet/model/date/Date.java
+++ b/src/main/java/seedu/partyplanet/model/date/Date.java
@@ -14,17 +14,23 @@ import java.time.temporal.ChronoUnit;
  * Guarantees: immutable; is always valid.
  */
 public class Date implements Comparable<Date> {
-    public static final String MESSAGE_CONSTRAINTS = "    - yyyy-mm-dd (ISO format)\n"
+
+    public static final String MESSAGE_YEAR_FORMATS = "    - yyyy-mm-dd (ISO format)\n"
             + "    - dd.mm.yyyy\n"
             + "    - dd/mm/yyyy\n"
             + "    - dd mmm yyyy\n"
             + "    - mmm dd yyyy";
-
+    public static final String MESSAGE_NOYEAR_FORMATS = "    - --mm-dd (ISO format)\n"
+            + "    - dd/mm\n"
+            + "    - dd mmm\n"
+            + "    - mmm dd";
+    public static final String MESSAGE_CONSTRAINTS = "Dates should be in one of the following formats:"
+            + MESSAGE_YEAR_FORMATS + "\n" + MESSAGE_NOYEAR_FORMATS;
     public static final String MESSAGE_YEAR_CONSTRAINTS = "A year is required for the input\n";
     public static final String EMPTY_DATE_STRING = "";
 
-    private static int MIN_YEAR = 0;
-    private static int NON_YEAR = -1;
+    protected static int MIN_YEAR = 0;
+    protected static int NON_YEAR = -1;
 
     protected static final DateTimeFormatter[] VALID_FORMATS = new DateTimeFormatter[] {
             DateTimeFormatter.ofPattern("yyyy-MM-dd"),
@@ -43,12 +49,10 @@ public class Date implements Comparable<Date> {
             DateTimeFormatter.ofPattern("MMM d"),
             DateTimeFormatter.ofPattern("MMMM d"),
     };
-    protected static final DateTimeFormatter ISO_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    protected static final DateTimeFormatter ISO_FORMAT_WITHOUT_YEAR = DateTimeFormatter.ofPattern("--MM-dd");
     protected static final DateTimeFormatter READABLE_FORMAT = DateTimeFormatter.ofPattern("d MMM yyyy");
     protected static final DateTimeFormatter READABLE_FORMAT_WITHOUT_YEAR = DateTimeFormatter.ofPattern("d MMM");
 
-    /** In "dd mmm yyyy" formatted string for human-readable display */
+     /** In "dd mmm yyyy" formatted string for human-readable display */
     public final String value;
     protected LocalDate date;
     protected boolean isEmpty = false;
@@ -168,8 +172,12 @@ public class Date implements Comparable<Date> {
      * Returns the number of days left till the date, relative to {@code reference}.
      * If {@code ignoreYear} is set to 'true', the number of days to the next month and day
      * is returned, i.e. the date is treated as a yearly event.
+     * If date is empty, the maximum possible days remaining value is returned (LONG_MAX).
      */
     public long getDaysLeft(boolean ignoreYear, LocalDate reference) {
+        if (isEmpty) {
+            return Long.MAX_VALUE;
+        }
         if (!ignoreYear) {
             return ChronoUnit.DAYS.between(reference, date);
         }

--- a/src/main/java/seedu/partyplanet/model/event/EventDate.java
+++ b/src/main/java/seedu/partyplanet/model/event/EventDate.java
@@ -1,5 +1,7 @@
 package seedu.partyplanet.model.event;
 
+import static seedu.partyplanet.commons.util.AppUtil.checkArgument;
+
 import seedu.partyplanet.model.date.Date;
 
 /** Represents an Event's date in PartyPlanet.
@@ -9,6 +11,7 @@ public class EventDate extends Date {
 
     public static final String MESSAGE_CONSTRAINTS = "Event dates should be in one of the following formats:\n"
             + MESSAGE_YEAR_FORMATS + "\n" + MESSAGE_NOYEAR_FORMATS;
+    public static final String MESSAGE_YEAR_CONSTRAINTS = "A year is required for the input\n";
     public static final EventDate EMPTY_EVENT_DATE = new EventDate();
 
     /**
@@ -19,7 +22,8 @@ public class EventDate extends Date {
      * @param eventDate A valid eventDate.
      */
     public EventDate(String eventDate) {
-        super(eventDate, true);
+        super(eventDate);
+        checkArgument(hasYear(), MESSAGE_YEAR_CONSTRAINTS);
     }
 
     /**

--- a/src/main/java/seedu/partyplanet/model/event/EventDate.java
+++ b/src/main/java/seedu/partyplanet/model/event/EventDate.java
@@ -8,8 +8,7 @@ import seedu.partyplanet.model.date.Date;
 public class EventDate extends Date {
 
     public static final String MESSAGE_CONSTRAINTS = "Event dates should be in one of the following formats:\n"
-            + Date.MESSAGE_CONSTRAINTS;
-
+            + MESSAGE_YEAR_FORMATS + "\n" + MESSAGE_NOYEAR_FORMATS;
     public static final EventDate EMPTY_EVENT_DATE = new EventDate();
 
     /**
@@ -36,25 +35,4 @@ public class EventDate extends Date {
     public static boolean isValidEventDate(String test) {
         return isValidDate(test);
     }
-
-
-    @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-        if (!(other instanceof EventDate)) {
-            return false;
-        }
-        if (isEmpty == EventDate.isEmptyDate((EventDate) other)) {
-            return true;
-        }
-        return value.equals(((EventDate) other).value);
-    }
-
-    @Override
-    public int hashCode() {
-        return value.hashCode();
-    }
-
 }

--- a/src/main/java/seedu/partyplanet/model/person/Birthday.java
+++ b/src/main/java/seedu/partyplanet/model/person/Birthday.java
@@ -12,7 +12,7 @@ import seedu.partyplanet.model.date.Date;
 public class Birthday extends Date {
 
     public static final String MESSAGE_CONSTRAINTS = "Birthdays should be in one of the following formats:\n"
-            + Date.MESSAGE_CONSTRAINTS;
+            + MESSAGE_YEAR_FORMATS + "\n" + MESSAGE_NOYEAR_FORMATS;
     public static final String MESSAGE_BIRTHDAY_CONSTRAINTS = "Birthday should not be a date in the future";
     public static final Birthday EMPTY_BIRTHDAY = new Birthday();
 
@@ -25,7 +25,7 @@ public class Birthday extends Date {
      */
     public Birthday(String birthdate) {
         super(birthdate, false);
-        checkArgument(isValidBirthdayDate(value), MESSAGE_BIRTHDAY_CONSTRAINTS);
+        checkArgument(isValidBirthdayDate(birthdate), MESSAGE_BIRTHDAY_CONSTRAINTS);
     }
 
     /**
@@ -33,6 +33,24 @@ public class Birthday extends Date {
      */
     public Birthday() {
         super();
+    }
+
+    /**
+     * Returns true if a given date string is a valid date not in the future.
+     */
+    public static boolean isFuture(String test) {
+        return isFuture(test, LocalDate.now());
+    }
+
+    /**
+     * Returns true if a given date string is a valid date not after {@code reference}.
+     * Exposes {@reference} date as a parameter for unit testing.
+     * Note: Dates without years which are parsed successfully are always considered not from the future.
+     */
+    public static boolean isFuture(String test, LocalDate reference) {
+        assert isValidDate(test);
+        LocalDate date = parseDate(test);
+        return reference.isBefore(date);
     }
 
     /**
@@ -52,44 +70,19 @@ public class Birthday extends Date {
     }
 
     /**
-     * Returns the month value of the birthday, in the range [1-12].
-     * Required for feature to filter contact birthdays by month.
+     * Returns 0 if equal, otherwise positive (negative) integer if monthDay is earlier (later).
+     * Empty dates are always treated as later dates.
      */
-    public int getMonth() {
+    public int compareTo(Birthday other) {
+        if (isEmpty && isEmptyDate(other)) {
+            return 0;
+        }
         if (isEmpty) {
-            throw new IllegalArgumentException("Birthday is empty");
+            return 1;
         }
-        return month;
-    }
-
-    @Override
-    public int compareTo(Date other) {
-        return getMonthDayString().compareTo(other.getMonthDayString());
-    }
-
-
-    @Override
-    public String toString() {
-        return displayValue;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
+        if (isEmptyDate(other)) {
+            return -1;
         }
-        if (!(other instanceof Birthday)) {
-            return false;
-        }
-        if (isEmpty == Birthday.isEmptyDate((Birthday) other)) {
-            return true;
-        }
-        return value.equals(((Birthday) other).value);
+        return date.withYear(NON_YEAR).compareTo(other.date.withYear(NON_YEAR));
     }
-
-    @Override
-    public int hashCode() {
-        return value.hashCode();
-    }
-
 }

--- a/src/main/java/seedu/partyplanet/model/person/Birthday.java
+++ b/src/main/java/seedu/partyplanet/model/person/Birthday.java
@@ -24,7 +24,7 @@ public class Birthday extends Date {
      * @param birthdate A valid birthdate.
      */
     public Birthday(String birthdate) {
-        super(birthdate, false);
+        super(birthdate);
         checkArgument(isValidBirthdayDate(birthdate), MESSAGE_BIRTHDAY_CONSTRAINTS);
     }
 
@@ -67,22 +67,5 @@ public class Birthday extends Date {
      */
     public static boolean isValidBirthdayDate(String test, LocalDate reference) {
         return isValidDate(test) && !isFuture(test, reference);
-    }
-
-    /**
-     * Returns 0 if equal, otherwise positive (negative) integer if monthDay is earlier (later).
-     * Empty dates are always treated as later dates.
-     */
-    public int compareTo(Birthday other) {
-        if (isEmpty && isEmptyDate(other)) {
-            return 0;
-        }
-        if (isEmpty) {
-            return 1;
-        }
-        if (isEmptyDate(other)) {
-            return -1;
-        }
-        return date.withYear(NON_YEAR).compareTo(other.date.withYear(NON_YEAR));
     }
 }

--- a/src/main/java/seedu/partyplanet/storage/JsonAdaptedEvent.java
+++ b/src/main/java/seedu/partyplanet/storage/JsonAdaptedEvent.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.partyplanet.commons.exceptions.IllegalValueException;
 import seedu.partyplanet.logic.parser.exceptions.ParseException;
-import seedu.partyplanet.model.date.Date;
 import seedu.partyplanet.model.event.Event;
 import seedu.partyplanet.model.event.EventDate;
 import seedu.partyplanet.model.person.Name;
@@ -74,7 +73,7 @@ class JsonAdaptedEvent {
             } catch (DateTimeException err) { // date in wrong format
                 throw new ParseException(EventDate.MESSAGE_CONSTRAINTS);
             } catch (IllegalArgumentException err) { // no year field;
-                throw new ParseException(Date.MESSAGE_YEAR_CONSTRAINTS);
+                throw new ParseException(EventDate.MESSAGE_YEAR_CONSTRAINTS);
             }
         }
 

--- a/src/main/java/seedu/partyplanet/ui/EventCard.java
+++ b/src/main/java/seedu/partyplanet/ui/EventCard.java
@@ -46,7 +46,7 @@ public class EventCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         name.setText(getTitle(event));
         if (!EventDate.isEmptyDate(event.getEventDate())) {
-            addDetail(event.getEventDate().displayValue);
+            addDetail(event.getEventDate().value);
         }
         if (!Remark.isEmptyRemark(event.getDetails())) {
             addDetail(event.getDetails().value);

--- a/src/main/java/seedu/partyplanet/ui/PersonCard.java
+++ b/src/main/java/seedu/partyplanet/ui/PersonCard.java
@@ -62,7 +62,7 @@ public class PersonCard extends UiPart<Region> {
             addDetail(person.getEmail().value);
         }
         if (!Birthday.isEmptyDate(person.getBirthday())) {
-            addDetail(person.getBirthday().displayValue);
+            addDetail(person.getBirthday().value);
         }
         if (!Remark.isEmptyRemark(person.getRemark())) {
             addDetail(person.getRemark().value);

--- a/src/test/java/seedu/partyplanet/model/date/DateTest.java
+++ b/src/test/java/seedu/partyplanet/model/date/DateTest.java
@@ -1,0 +1,30 @@
+package seedu.partyplanet.model.date;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class DateTest {
+
+    @Test
+    public void compareTo() {
+        // Same year
+        Date date0606 = new Date("2020-06-06");
+        Date dateNoYear0606 = new Date("--06-06");
+        Date dateNoYear0607 = new Date("--06-07");
+        Date date0608 = new Date("2020-06-08");
+
+        // Different year
+        Date datePrevYear = new Date("2019-08-13");
+
+        // Dates with no years are smaller
+        assertTrue(date0606.compareTo(dateNoYear0607) > 0);
+        assertTrue(dateNoYear0606.compareTo(dateNoYear0607) < 0);
+        assertTrue(dateNoYear0606.compareTo(date0608) < 0);
+
+        // Different date
+        assertTrue(date0606.compareTo(date0608) < 0);
+        assertTrue(date0608.compareTo(datePrevYear) > 0);
+        assertTrue(datePrevYear.compareTo(date0606) < 0);
+    }
+}

--- a/src/test/java/seedu/partyplanet/model/event/EventDateTest.java
+++ b/src/test/java/seedu/partyplanet/model/event/EventDateTest.java
@@ -5,14 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.partyplanet.testutil.Assert.assertThrows;
 
-import java.time.DateTimeException;
 import java.time.LocalDate;
-import java.time.MonthDay;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
-
-import seedu.partyplanet.model.date.Date;
 
 public class EventDateTest {
 
@@ -23,9 +19,9 @@ public class EventDateTest {
     }
 
     @Test
-    public void constructor_invalidEventDate_throwsDateTimeException() {
+    public void constructor_invalidEventDate_throwsIllegalArgumentException() {
         String invalidEventDate = "";
-        assertThrows(DateTimeException.class, () -> new EventDate(invalidEventDate));
+        assertThrows(IllegalArgumentException.class, () -> new EventDate(invalidEventDate));
     }
 
     @Test
@@ -56,28 +52,7 @@ public class EventDateTest {
             assertTrue(EventDate.isValidEventDate(validInput));
         }
         assertEquals(1, Arrays.stream(validInputs)
-                .map(Date::parseDate)
-                .map(x -> (LocalDate) x)
-                .distinct()
-                .count());
-    }
-
-    @Test
-    public void isValidEventDate_validWithoutYears() {
-        String[] validInputs = new String[]{
-            "--02-03",
-            "3/2",
-            "3 Feb",
-            "3 February",
-            "Feb 3",
-            "February 3",
-        };
-        for (String validInput: validInputs) {
-            assertTrue(EventDate.isValidEventDate(validInput));
-        }
-        assertEquals(1, Arrays.stream(validInputs)
-                .map(Date::parseDate)
-                .map(x -> (MonthDay) x)
+                .map(EventDate::new)
                 .distinct()
                 .count());
     }
@@ -95,24 +70,6 @@ public class EventDateTest {
         assertTrue(EventDate.isValidEventDate("2020-06-05"));
         assertTrue(EventDate.isValidEventDate("2025-06-06"));
         assertTrue(EventDate.isValidEventDate("9999-06-07"));
-    }
-
-    @Test
-    public void compareTo() {
-        // Same year
-        EventDate localDate0606 = new EventDate("2020-06-06");
-        EventDate localDate0608 = new EventDate("2020-06-08");
-
-        // Different year
-        EventDate localDatePrevYear = new EventDate("2019-08-13");
-
-        // Same date
-        assertEquals(0, localDate0606.compareTo(localDate0606));
-
-        // Different date
-        assertTrue(localDate0606.compareTo(localDate0608) < 0);
-        assertTrue(localDate0608.compareTo(localDatePrevYear) > 0);
-        assertTrue(localDatePrevYear.compareTo(localDate0606) < 0);
     }
 }
 

--- a/src/test/java/seedu/partyplanet/model/person/BirthdayTest.java
+++ b/src/test/java/seedu/partyplanet/model/person/BirthdayTest.java
@@ -5,14 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.partyplanet.testutil.Assert.assertThrows;
 
-import java.time.DateTimeException;
 import java.time.LocalDate;
-import java.time.MonthDay;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
-
-import seedu.partyplanet.model.date.Date;
 
 public class BirthdayTest {
 
@@ -24,7 +20,7 @@ public class BirthdayTest {
     @Test
     public void constructor_invalidBirthday_throwsDateTimeException() {
         String invalidBirthday = "";
-        assertThrows(DateTimeException.class, () -> new Birthday(invalidBirthday));
+        assertThrows(IllegalArgumentException.class, () -> new Birthday(invalidBirthday));
     }
 
     @Test
@@ -92,30 +88,5 @@ public class BirthdayTest {
         assertTrue(Birthday.isValidBirthdayDate("2021-06-05", referenceDate));
         assertTrue(Birthday.isValidBirthdayDate("2021-06-06", referenceDate));
         assertFalse(Birthday.isValidBirthdayDate("2021-06-07", referenceDate));
-    }
-
-    @Test
-    public void compareTo() {
-        // Same year
-        Birthday localDate0606 = new Birthday("2020-06-06");
-        Birthday monthDay0606 = new Birthday("--06-06");
-        Birthday monthDay0607 = new Birthday("--06-07");
-        Birthday localDate0608 = new Birthday("2020-06-08");
-
-        // Different year
-        Birthday localDatePrevYear = new Birthday("2019-08-13");
-
-        // Same date
-        assertEquals(0, localDate0606.compareTo(localDate0606));
-        assertEquals(0, monthDay0606.compareTo(monthDay0606));
-        assertEquals(0, localDate0606.compareTo(monthDay0606));
-
-        // Different date
-        assertTrue(localDate0606.compareTo(monthDay0607) < 0);
-        assertTrue(monthDay0606.compareTo(monthDay0607) < 0);
-        assertTrue(localDate0606.compareTo(localDate0608) < 0);
-        assertTrue(monthDay0607.compareTo(localDate0608) < 0);
-        assertTrue(localDate0608.compareTo(localDatePrevYear) < 0);
-        assertTrue(localDatePrevYear.compareTo(localDate0606) > 0);
     }
 }

--- a/src/test/java/seedu/partyplanet/model/person/BirthdayTest.java
+++ b/src/test/java/seedu/partyplanet/model/person/BirthdayTest.java
@@ -55,8 +55,7 @@ public class BirthdayTest {
             assertTrue(Birthday.isValidBirthdayDate(validInput));
         }
         assertEquals(1, Arrays.stream(validInputs)
-                .map(Date::parseDate)
-                .map(x -> (LocalDate) x)
+                .map(Birthday::new)
                 .distinct()
                 .count());
     }
@@ -75,8 +74,7 @@ public class BirthdayTest {
             assertTrue(Birthday.isValidBirthdayDate(validInput));
         }
         assertEquals(1, Arrays.stream(validInputs)
-                .map(Date::parseDate)
-                .map(x -> (MonthDay) x)
+                .map(Birthday::new)
                 .distinct()
                 .count());
     }


### PR DESCRIPTION
### Internal changes

- Refactor `Date` to use `LocalDate` as internal representation instead of ISO format strings.
  - Avoids need to keep parsing ISO string as `LocalDate` in order to use comparison / date attribute retrieval.
  - Alternative is to use `TemporalAccessor` to store either `LocalDate` or `MonthDay`, but every attempt to retrieve an attribute (e.g. a month) requires type checking + casting.
  - Dates without years are now represented using `NON_YEAR` to replace the year field (defined as `-1`)
- Shift subclass requirements away from `Date`, e.g.
  - Year constraints for `EventDate`
  - Future constraints for `Birthday`
- Remove redundant methods in `Birthday` and `EventDate` classes, making heavier use of method inheritance.

#### Summary of related file changes:

1. Date
   - Use of `dateValue` to represent a date -> refactor `getMonth`, `hasYear`, `compareTo`
   - Add constant `MIN_YEAR = 0`: Dates can only accept positive year values
   - Add constant `NON_YEAR = -1`: Defines a month-day, i.e. `LocalDate` without a valid year
   - Modify `parseDate`: Adds `MIN_YEAR` check + sets `NON_YEAR` for month-days
   - Implement `getDateWithoutYear`: Removes any year references to compare bday
   - Implement `getDaysLeft`: Calculate remaining days to sort by upcoming
   - Implement `hasYear`: Used as check in `EventDate`
   - Bugfix `compareTo` and `equals`: Allow comparison with empty dates
2. EventDate: Refactor
3. Birthday: Refactor (n.b. `isFuture` ported from previous `Date` impl.)
4. DateTest: Refactor
5. EventDateTest: Refactor
6. BirthdayTest: Refactor
7. JsonAdaptedEvent: Refactor
8. EventCard: Refactor
9. PersonCard: Refactor


----

### Feature changes

- Update date sorting behavior to account for empty dates.
  - (Dates without year) < (Dates with year) < (Empty dates)
  - MonthDay comparisons utilize comparison between dates obtained from `Date.getDateWithoutYear`, to avoid confusion with default `Date` comparison method
- Add ability to sort by upcoming dates for both contacts and events (fixes #138, fixes #181).
  - Achieved using `Date.getDaysLeft` to allow sorting of events and contacts by upcoming dates.

#### Summary of related file changes:

10. EListCommand: Add sort by upcoming comparator.
11. ListCommand: Add sort by upcoming comparator.
12. EListParser: Use sort by upcoming comparator.
13. ListParser: Use sort by upcoming comparator.

---

### Test syntax

`list [...] --sort upcoming` (alias: `u`)
`elist [...] --sort upcoming` (alias: `u`)

As noted by @garyljj, sort by upcoming for both `list` and `elist` is [not intended to work](https://github.com/AY2021S2-CS2103-W16-3/tp/pull/180#discussion_r602715762) with `--order desc`.

### Required follow-up:

1. Update documentation
2. Reduce method visibilities to better adhere to principle of least knowledge
3. Define a range of valid years more explicitly in documentation and help command, i.e. years must be non-negative

### Implementation notes

1. Birthday sorting behavior remains mostly unchanged, except contacts with no birthdays are now sorted to the back (left: before, right: after)

![image](https://user-images.githubusercontent.com/28663438/112532852-484d0880-8de4-11eb-88db-f7992ea3d96d.png)

2. Birthday sorting by upcoming orders the contacts by month and day only, without consideration for year, as well as in order of which birthday will come first.

![image](https://user-images.githubusercontent.com/28663438/112533071-86e2c300-8de4-11eb-9ba0-139e88cf15ea.png)

3. EventDate sorting behavior is unchanged.
4. EventDate sorting by upcoming orders the events in chronological order, and additionally shifting all done events to the end of the event list.
   - Another alternative is to push the overdue and not done events to the end as well, for an 'upcoming' sort behavior more similar to that of Birthday.

![image](https://user-images.githubusercontent.com/28663438/112533807-4a639700-8de5-11eb-90a5-6971ee565ea5.png)


