### PR TITLE
Block edit action when both index and remove flag are present

### DIFF
--- a/src/main/java/seedu/partyplanet/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/EditCommandParser.java
@@ -42,7 +42,11 @@ public class EditCommandParser implements Parser<EditCommand> {
                         PREFIX_BIRTHDAY, PREFIX_ADDRESS, PREFIX_REMARK, PREFIX_TAG);
 
         boolean hasIndex = !argMultimap.getPreamble().isEmpty();
-        boolean mentionsDelete = argMultimap.getValue(FLAG_REMOVE).isPresent();
+        boolean mentionsRemove = argMultimap.getValue(FLAG_REMOVE).isPresent();
+
+        if (hasIndex && mentionsRemove) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+        }
 
         if (hasIndex) {
 
@@ -81,7 +85,7 @@ public class EditCommandParser implements Parser<EditCommand> {
 
             return new EditFieldCommand(index, editPersonDescriptor);
 
-        } else if (mentionsDelete) {
+        } else if (mentionsRemove) {
 
             if (!argMultimap.getValue(PREFIX_TAG).isPresent()) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));


### PR DESCRIPTION
To prevent ambiguity
Previously: when both `INDEX` and `--remove` are present, edit ignores `--remove` and proceeds with editing person at `INDEX` like normal
Now: edit throws error to block action, only allows either `INDEX` or `--remove` to be present but not both