### PR TITLE
Update GUI visuals

### DIFF
--- a/src/main/java/seedu/partyplanet/ui/EventCard.java
+++ b/src/main/java/seedu/partyplanet/ui/EventCard.java
@@ -43,7 +43,7 @@ public class EventCard extends UiPart<Region> {
     public EventCard(Event event, int displayedIndex) {
         super(FXML);
         this.event = event;
-        id.setText(displayedIndex + ". ");
+        id.setText("⟨ " + displayedIndex + " ⟩");
         name.setText(getTitle(event));
         if (!EventDate.isEmptyDate(event.getEventDate())) {
             addDetail(event.getEventDate().value);

--- a/src/main/java/seedu/partyplanet/ui/PersonCard.java
+++ b/src/main/java/seedu/partyplanet/ui/PersonCard.java
@@ -50,7 +50,7 @@ public class PersonCard extends UiPart<Region> {
     public PersonCard(Person person, int displayedIndex) {
         super(FXML);
         this.person = person;
-        id.setText(displayedIndex + ". ");
+        id.setText("⟨ " + displayedIndex + " ⟩");
         name.setText(person.getName().fullName);
         if (!Phone.isEmptyPhone(person.getPhone())) {
             addDetail(person.getPhone().value);

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -118,13 +118,18 @@
 }
 
 .cell_big_label {
-    -fx-font-size: 16px;
+    -fx-font-size: 15px;
     -fx-text-fill: #010504;
 }
 
+.cell_id_name_box {
+    -fx-padding: 0 0 4 0;
+}
+
 .cell_small_label {
-    -fx-font-size: 13px;
+    -fx-font-size: 14px;
     -fx-text-fill: #010504;
+    -fx-padding: 2 0 0 0;
 }
 
 .stack-pane {
@@ -305,6 +310,7 @@
 #cardPane {
     -fx-background-color: transparent;
     -fx-border-width: 0;
+    -fx-padding: 1 0 3 0;
 }
 
 #commandTypeLabel {
@@ -334,6 +340,7 @@
 #tags {
     -fx-hgap: 7;
     -fx-vgap: 3;
+    -fx-padding: 2 0 4 0;
 }
 
 #tags .label {

--- a/src/main/resources/view/EventListCard.fxml
+++ b/src/main/resources/view/EventListCard.fxml
@@ -13,12 +13,12 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox fx:id = "details" alignment="TOP_LEFT" minHeight="50" GridPane.columnIndex="0">
+    <VBox fx:id = "details" alignment="TOP_LEFT" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label fx:id="id" styleClass="cell_big_label">
+      <HBox spacing="5" alignment="CENTER_LEFT" styleClass="cell_id_name_box">
+        <Label fx:id="id" styleClass="cell_small_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />

--- a/src/main/resources/view/Font.css
+++ b/src/main/resources/view/Font.css
@@ -34,11 +34,11 @@
 }
 
 .cell_big_label {
-    -fx-font-family: "Tisa Sans Pro Medium";
+    -fx-font-family: "Tisa Sans Pro";
 }
 
 .cell_small_label {
-    -fx-font-family: "Tisa Sans Pro Regular";
+    -fx-font-family: "Tisa Sans Pro Light";
 }
 
 .result-display {

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -14,12 +14,12 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox fx:id = "details" alignment="TOP_LEFT" minHeight="50" GridPane.columnIndex="0">
+    <VBox fx:id = "details" alignment="TOP_LEFT" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label fx:id="id" styleClass="cell_big_label">
+      <HBox spacing="5" alignment="CENTER_LEFT" styleClass="cell_id_name_box">
+        <Label fx:id="id" styleClass="cell_small_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />

--- a/src/main/resources/view/PinkPastelTheme.css
+++ b/src/main/resources/view/PinkPastelTheme.css
@@ -184,7 +184,7 @@
 }
 
 .context-menu {
-    -fx-background-color: derive(#1d1d1d, 50%);
+    -fx-background-color: derive(rgb(183, 159, 153), 10%);
 }
 
 .context-menu .label {
@@ -203,6 +203,14 @@
 
 .menu .left-container {
     -fx-background-color: black;
+}
+
+.menu:hover, .menu:showing {
+    -fx-background-color: derive(rgb(183, 159, 153), 30%);
+}
+
+.menu-item:focused {
+    -fx-background-color: derive(rgb(183, 159, 153), 50%);
 }
 
 /*

--- a/src/main/resources/view/PinkPastelTheme.css
+++ b/src/main/resources/view/PinkPastelTheme.css
@@ -120,13 +120,18 @@
 }
 
 .cell_big_label {
-    -fx-font-size: 16px;
+    -fx-font-size: 15px;
     -fx-text-fill: #010504;
 }
 
+.cell_id_name_box {
+    -fx-padding: 0 0 4 0;
+}
+
 .cell_small_label {
-    -fx-font-size: 13px;
+    -fx-font-size: 14px;
     -fx-text-fill: #010504;
+    -fx-padding: 2 0 0 0;
 }
 
 .stack-pane {
@@ -315,6 +320,7 @@
 #cardPane {
     -fx-background-color: transparent;
     -fx-border-width: 0;
+    -fx-padding: 1 0 3 0;
 }
 
 #commandTypeLabel {
@@ -345,6 +351,7 @@
 #tags {
     -fx-hgap: 7;
     -fx-vgap: 3;
+    -fx-padding: 2 0 4 0;
 }
 
 #tags .label {


### PR DESCRIPTION
## Main change: 80b3bfd

Adjust menu hover color palette to align with pastel theme.

![image](https://user-images.githubusercontent.com/28663438/112875622-00392900-90f7-11eb-8ccc-b5e6ea38b30f.png) ----> ![image](https://user-images.githubusercontent.com/28663438/112875671-10e99f00-90f7-11eb-8d9a-c4e0ba80ffcc.png)

## Secondary change: 26255c5

### Motivation

1. Font aliasing for `Tisa Sans Pro Medium` (contact / event ID / title) is strong, mainly due to weight of font.
   - Secondary observation: heavier weight causes already short text, e.g. `1`, to appear even shorter, see below for comparison with `Tisa Sans Pro Regular`.
   - Cannot change to `Tisa Sans Pro Light`, which reduces aliasing effects, but has mismatch with unicode tick for done events

![image](https://user-images.githubusercontent.com/28663438/112876510-2e6b3880-90f8-11eb-9152-0af1e9375721.png)

2. Descriptive field text is relatively small compared to the title
   - Doubled emphasis of title, i.e. bold + larger size
   - Small size of description can occasional yield aliasing effects as well
   - Font sizes are made more similar to each other
3. Crowded fields + minimal padding for each contact / event
   - Adding padding between fields + contact / event container padding
4. Bulleted fields is inadvertently compared with the dot following the ID, which gives a sense of misalignment
   - Cannot simply add left padding for fields since each ID has independent width (prevent inadvertent hiding of ID with fixed container width)
   - Changed ID styling to shift away from use of dot

### Constraints

- Reuse `Tisa Sans Pro` font

### Side-effects

- Each contact / event container takes up roughly 10-20% more vertical height
- More even font weights for better consistency => Less distinguishability between disparate fields

### Before

![20210330_012845](https://user-images.githubusercontent.com/28663438/112876062-9a996c80-90f7-11eb-90a5-0fce0eaf54b9.png)

### After

![20210330_012828](https://user-images.githubusercontent.com/28663438/112876082-a127e400-90f7-11eb-91e3-2284ba13af3c.png)
