### PR TITLE
Fix undo redo bug 

### DIFF
--- a/src/main/java/seedu/partyplanet/ui/CommandBox.java
+++ b/src/main/java/seedu/partyplanet/ui/CommandBox.java
@@ -89,24 +89,25 @@ public class CommandBox extends UiPart<Region> {
         case Z:
             try {
                 if (event.isShiftDown() && event.isShortcutDown()) {
+                    commandTextField.clear();
                     commandExecutor.execute("redo");
-                } else if (event.isControlDown()) {
+                } else if (event.isShortcutDown()) {
+                    commandTextField.clear();
                     commandExecutor.execute("undo");
                 }
             } catch (CommandException | ParseException e) {
                 setStyleToIndicateCommandFailure();
             }
-            commandTextField.clear();
             break;
         case Y:
             try {
                 if (event.isShortcutDown()) {
+                    commandTextField.clear();
                     commandExecutor.execute("redo");
                 }
             } catch (CommandException | ParseException e) {
                 setStyleToIndicateCommandFailure();
             }
-            commandTextField.clear();
             break;
         default:
             break;


### PR DESCRIPTION
Whenever typing anything with y or z, command test field automatically clears.

Shifted commandTextField.clear() up to handle bug.

(Credits to @garyljj for helping me solve the bug)