### PR TITLE
Update contact command description in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -95,7 +95,7 @@ commands prepended with `e` operate on the event list.
 | Mark as done | no contact-equivalent, `edone` (event) |
 
 Other app-wide commands are also available.
-These commands do not process any additional parameters.
+These commands do not process any additional parameters, including the single-argument `help` command.
 
 | Action | Command |
 |---|---|

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -145,7 +145,7 @@ Edits an existing person in the contact list.
 Format: `edit {INDEX [-n NAME] [-p PHONE] [-e EMAIL] [-a ADDRESS] [-t TAG]…​ [-b BIRTHDAY] [-r REMARK] | --remove -t TAG [-t TAG}…​}`
 1. If index supplied, `edit INDEX [...]`: Edits the person at the specified `INDEX`
    * Existing values are replaced by the input values, if specified.
-   * To retrieve existing values, use the autocompletion workflow specified below.
+   * To retrieve existing values, use the autocompletion workflow specified [below](#autocomplete-tab).
    * Tags can be removed from a contact by specifying a standalone `-t` without parameters.
 2. If `--remove` flag specified, `edit --remove -t TAG [-t TAG]...`: Removes all specified tags from every contact in the displayed list
    * All specified tags will be removed from every contact in the displayed list.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -51,21 +51,21 @@ PartyPlanet can get the planning of your birthday celebrations done faster than 
 
 ## Glossary of parameters
 
-| Parameter | Description |
-|---|---|
-| `ADDRESS` | Any value |
-| `BIRTHDAY` | Valid date, with or without a year:{::nomarkdown}<ul><li>Year must be non-negative if specified, and birthday must be in the past</li><li>If the year is incompatible with the date, the closest valid date will be matched<br>e.g. <code>29 Feb 2021</code> is mapped to <code>28 Feb 2021</code></li><li>Accepted date formats are listed below, case-insensitive:<ul><li>ISO format: <code>--01-09</code> / <code>1997-01-09</code></li><li>Dot delimited: <code>9.1</code> / <code>9.1.1997</code></li><li>Slash delimited: <code>9/1</code> / <code>9/1/1997</code></li><li>Long DMY format: <code>9 Jan</code> / <code>9 Jan 1997</code></li><li>Full DMY format: <code>9 January</code> / <code>9 January 1997</code></li><li>Long YMD format: <code>Jan 9</code> / <code>Jan 9 1997</code></li><li>Full YMD format: <code>January 9</code> / <code>January 9 1997</code></li></ul></li></ul>{:/} |
-| `COMMAND` | Any valid command listed [below](#party-planet-commands) |
-| `DATE` | Valid date with a year:{::nomarkdown}<ul><li>Year must be present and non-negative</li><li>See <code>BIRTHDAY</code> parameter above for available date formats</li></ul>{:/} |
-| `DETAIL` | Any value |
-| `EMAIL` | In the format `USER@DOMAIN`:{::nomarkdown}<ul><li><code>USER</code> can only contain alphanumerics and any of <code>!#$%&'*+/=?`{&#124;}~^.-</code></li><li><code>DOMAIN</code> must be at least two characters long, start and end with two alphanumerics, and consist only of alphanumerics, periods or hyphens</li></ul>{:/} |
-| `INDEX` | Positive integer representing the ID present in the filtered list |
-| `NAME` | Any value containing only alphanumerics and spaces |
-| `PHONE` | Any number at least three digits long |
-| `REMARK` | Any value |
-| `SORT_FIELD` | Any valid option, specified below in `list` and `elist` commands |
-| `SORT_ORDER` | Any of the following:{::nomarkdown}<ul><li><code>a</code>, <code>asc</code>, <code>ascending</code> (ascending order)</li><li><code>d</code>, <code>desc</code>, <code>descending</code> (descending order)</li></ul>{:/} |
-| `TAG` | Any value containing only alphanumeric characters |
+| Parameter | Prefix | Applicable to | Description |
+|---|---|---|---|
+| `ADDRESS` | `-a`, `--address` | Contact | Any value |
+| `BIRTHDAY` | `-b`, `--birthday` | Contact | Valid date, with or without a year:{::nomarkdown}<ul><li>Year must be non-negative if specified, and birthday must be in the past</li><li>If the year is incompatible with the date, the closest valid date will be matched<br>e.g. <code>29 Feb 2021</code> is mapped to <code>28 Feb 2021</code></li><li>Accepted date formats are listed below, case-insensitive:<ul><li>ISO format: <code>--01-09</code> / <code>1997-01-09</code></li><li>Dot delimited: <code>9.1</code> / <code>9.1.1997</code></li><li>Slash delimited: <code>9/1</code> / <code>9/1/1997</code></li><li>Long DMY format: <code>9 Jan</code> / <code>9 Jan 1997</code></li><li>Full DMY format: <code>9 January</code> / <code>9 January 1997</code></li><li>Long YMD format: <code>Jan 9</code> / <code>Jan 9 1997</code></li><li>Full YMD format: <code>January 9</code> / <code>January 9 1997</code></li></ul></li></ul>{:/} |
+| `COMMAND` | - | - | Any valid command listed [below](#party-planet-commands) |
+| `DATE` | `-d`, `--date` | Event | Valid date with a year:{::nomarkdown}<ul><li>Year must be present and non-negative</li><li>See <code>BIRTHDAY</code> parameter above for available date formats</li></ul>{:/} |
+| `DETAIL` | `-r`, `--remark` | Event | Any value |
+| `EMAIL` | `-e`, `--email` | Contact | In the format `USER@DOMAIN`:{::nomarkdown}<ul><li><code>USER</code> can only contain alphanumerics and any of <code>!#$%&'*+/=?`{&#124;}~^.-</code></li><li><code>DOMAIN</code> must be at least two characters long, start and end with two alphanumerics, and consist only of alphanumerics, periods or hyphens</li></ul>{:/} |
+| `INDEX` | - | any | Positive integer representing the ID present in the filtered list |
+| `NAME` | `-n`, `--name` | any | Any value containing only alphanumerics and spaces, unique to the contact/event list (case-sensitive) |
+| `PHONE` | `-p`, `--phone` | Contact | Any number at least three digits long |
+| `REMARK` | `-r`, `--remark` | Contact | Any value |
+| `SORT_FIELD` | `-s`, `--sort` | any | Any valid option, specified below in `list` and `elist` commands |
+| `SORT_ORDER` | `-o`, `--order` | any | Any of the following:{::nomarkdown}<ul><li><code>a</code>, <code>asc</code>, <code>ascending</code> (ascending order)</li><li><code>d</code>, <code>desc</code>, <code>descending</code> (descending order)</li></ul>{:/} |
+| `TAG` | `-t`, `--tag` | Contact | Any value containing only alphanumeric characters |
 
 <div markdown="block" class="alert alert-info">
 
@@ -81,85 +81,118 @@ PartyPlanet can get the planning of your birthday celebrations done faster than 
 
 ## Party Planet Commands
 
-### Adding contacts : `add`
+### Summary
 
-Adds a person to PartyPlanet's Contacts List.
+For data specific commands, the unqualified commands operate on the contact list, while
+commands prepended with `e` operate on the event list.
 
-Format: `add -n NAME [-p PHONE] [-e EMAIL] [-a ADDRESS] [-t TAG]…​ [-b BIRTHDAY]​ [-r REMARK]​`<br>
+| Action | Command |
+|---|---|
+| Adding new | `add` (contact), `eadd` (event) |
+| Edit existing | `edit` (contact), `eedit` (event) |
+| Delete existing | `delete` (contact), `edelete` (event) |
+| List / Search | `list` (contact), `elist` (event) |
+| Mark as done | no contact-equivalent, `edone` (event) |
+
+Other app-wide commands are also available.
+These commands do not process any additional parameters.
+
+| Action | Command |
+|---|---|
+| Undo / Redo | `undo`, `redo` |
+| Change theme | `theme` |
+| Show help | `help` |
+| Exit the app | `exit` |
+
+A special command invoked by pressing the `TAB` key instead of `Enter` exists for `edit` and `eedit` -  details specified
+in the autocomplete section.
+
+### Contact list commands
+
+#### Adding contacts : `add`
+
+Adds a person to the contact list.
+
+Format: `add -n NAME [-p PHONE] [-e EMAIL] [-a ADDRESS] [-t TAG]... [-b BIRTHDAY] [-r REMARK]`
 
 Examples:
+* `add -n John Doe`
 * `add -n James Ho -p 22224444 -e jamesho@example.com -a 123, Clementi Rd, 1234665 -t friend -t colleague -b 1 Jan
-  -r allergic to nuts` Adds a new person James Ho with specified details.
+  -r allergic to nuts` Adds a new person James Ho with specified details
 
-### Deleting contacts : `delete`
+#### Deleting contacts : `delete`
 
-Deletes person(s) from PartyPlanet's Contact List.
+Deletes person(s) from the contact list.
 
 Format: `delete [{INDEX [INDEX]... | [--any] -t TAG [-t TAG]...}]`
-* If no parameters: `delete`
-  * Deletes all persons in the displayed person list
-* If provided with index(es): `delete INDEX [INDEX]...`
-  * Deletes the person at the specified `INDEX`.
-  * All indexes refers to the index number shown in the displayed person list.
-* If provided with tags: `delete [--any] -t TAG [-t TAG]...`
-  * Delete every person who is tagged with all/any (`--any` specified) of the specified tags, in the displayed person list.
+1. If no parameters supplied, `delete`: Deletes all contacts in the displayed contact list
+2. If indices supplied, `delete INDEX [INDEX]...`: Deletes the contacts associated with each specified `INDEX`
+   * Invalid indices are ignored.
+3. If tags supplied, `delete [--any] -t TAG [-t TAG]...`: Delete the contacts containing all specified tags
+   * If the `--any` flag is supplied, contacts need only match with any specified tag.
 
 Examples:
 * `delete` deletes all contacts in current filtered list
-* `delete 3` deletes contact at 3rd index.
-* `delete 3 4 5` deletes contacts at 3rd, 4th and 5th index.
-* `delete -t colleague -t cs2103` deletes contact with both tag "colleague" and "cs2103".
+* `delete 3` deletes contact at the 3rd index
+* `delete 3 4 5` deletes contacts at the 3rd, 4th and 5th index
+* `delete -t colleague -t cs2103` deletes contacts that contain both tag "colleague" and "cs2103".
 * `delete --any -t colleague -t cs2103` deletes contacts with either tag "colleague" or tag "cs2103"
 
-### Editing contacts : `edit`
+#### Editing contacts : `edit`
 
-Edits an existing person in PartyPlanet's Contact List.
+Edits an existing person in the contact list.
 
 Format: `edit {INDEX [-n NAME] [-p PHONE] [-e EMAIL] [-a ADDRESS] [-t TAG]…​ [-b BIRTHDAY] [-r REMARK] | --remove -t TAG [-t TAG}…​}`
-
-* Editing specific person: `edit INDEX [-n NAME] [-p PHONE] [-e EMAIL] [-a ADDRESS] [-t TAG]…​ [-b BIRTHDAY] [-r REMARK]`
-  * Edits the person at the specified `INDEX`.
-  * Existing values will be updated to the input values.
-  * When editing tags, the existing tags of the person will be removed i.e. adding of tags is not cumulative.
-  * You can remove all the person’s tags by typing `-t` without specifying any tags after it.
-* `--remove` flag used: `edit --remove -t TAG [-t TAG}…​`
-  * All specified tags will be removed from persons in displayed list.
+1. If index supplied, `edit INDEX [...]`: Edits the person at the specified `INDEX`
+   * Existing values are replaced by the input values, if specified.
+   * To retrieve existing values, use the autocompletion workflow specified below.
+   * Tags can be removed from a contact by specifying a standalone `-t` without parameters.
+2. If `--remove` flag specified, `edit --remove -t TAG [-t TAG]...`: Removes all specified tags from every contact in the displayed list
+   * All specified tags will be removed from every contact in the displayed list.
 
 Examples:
-* `edit 2 -n James Lee -e jameslee@example.com` Edits the contact name to be “James Lee” and email address to be “jameslee@example.com”.
-* `edit 2 -n Betsy Crower -t` Edits the name of the 2nd person to be Betsy Crower and clears all existing tags.
-* `edit --remove -t friends` Removes the `friends` tag from Alex Yeoh and Charlotte Oliveiro.
+* `edit 2 -n James Lee -e jameslee@example.com` Edits the contact name to be "James Lee" and email address to be “jameslee@example.com”.
+* `edit 2 -n Betsy Crower -t` Edits the name of the 2nd person to be "Betsy Crower" and clears all existing tags.
+* `edit --remove -t friends` Removes the `friends` tag from every contact in the filtered list.
 
-### Listing contacts : `list`
+#### Listing contacts : `list`
 
-Shows a list of all persons in PartyPlanet's Contact List.
+Displays a list of contacts in the contact list, with optional search criteria.
 
-Format: `list [--exact] [--any] [-n NAME]... [-t TAG]... [-s SORT_FIELD] [-o SORT_ORDER]`
-* List out all contacts by default if no arguments specified.
-* `-n` and `-t` can be specified to filter the list by name and/or tag.
-  * Search is case-insensitive, e.g. `hans` will match `Hans`.
-  * Partial matches to names and tags are performed by default, e.g. `lliam` will match `williams`.
-  * If exact match is desired, specify an additional `--exact` flag.
-  * If multiple names/tags are specified, specifying `--any` filters contacts that fulfill any prefix match.
-* `-s` list out all contacts sorted according to `SORT_FIELD`. Possible values of `SORT_FIELD`:
-  * `n`: names in ascending lexicographical order
-  * `b`: birthdays from oldest to youngest
-* `-o` list out all contacts sorted according to `SORT_ORDER`. Possible values of `SORT_ORDER`:
-  * `asc`: ascending lexicographical order
-  * `desc`: descending lexicographical order
+Format: `list [--exact] [--any] [-n NAME]... [-t TAG]... [-b BIRTHDAY] [-s SORT_FIELD] [-o SORT_ORDER]`
+1. If no search parameters specified, `list [-s SORT_FIELD] [-o SORT_ORDER]`: List all contacts in contact list
+   * `-s` parameter optionally sorts contacts by `SORT_FIELD`:
+     * `n`, `name`: names in (case-sensitive) lexicographical order (by default, if `-s` not specified)
+     * `b`, `birthday`: day of the year of the birthday
+     * `u`, `upcoming`: days left to next upcoming birthday
+   * `-o` parameter optionally determines the direction of sort, according to `SORT_ORDER`:
+     * `a`, `asc`, `ascending`: ascending (by default, if `-o` not specified)
+     * `d`, `desc`, `descending`: descending
+     * Sorts by upcoming birthday do not accept the `descending` order
+2. If search parameters specified, `list [--exact] [--any] [-n NAME]... [-t TAG]... [-b BIRTHDAY] [-s SORT_FIELD] [-o SORT_ORDER]`: List all contacts matching the search criteria
+   * Search criteria, case-insensitive:
+     * `-n` filters the contacts by name
+     * `-t` filters the contacts by tags
+     * `-b` filters contacts by birthday month
+       * If `BIRTHDAY` is "0" or unspecified, filtered contacts do not have a birthday.
+       * Otherwise `BIRTHDAY` must be one of the 12 months, represented either by the month value or string,
+         i.e. `12`, `Dec`, `December` filters contacts with a birthday in December.
+  * Partial matches to names and tags are performed by default, unless `--exact` is specified for exact matches.
+  * All specified search criteria must be fulfilled by each contact by default, unless `--any` is specified for any match.
+  * The filtered contacts can be additionally sorted using the `-s` and `-o` prefixes, as above.
 
 Examples:
-* `list` Lists out all the contacts in PartyPlanet.
+* `list` Lists out all the contacts in the contact list.
 * `list -s asc` Lists out all the contacts in ascending lexicographical order.
 * `list -t friend` Lists out all contacts containing the tag "friend"
-* `list -n alice -t friend` Lists out all contacts whose name is "Alice" and have the "friend" tag
-* `list --any -n alice -t friend` Lists out all contacts whose name is "Alice" or who have the "friend" tag
-* `list --exact -n alice -t friend` Lists out all contacts whose name contain "Alice" and who have tags that contain "friend"
-* `list --exact --any -n alice -t friend` Lists out all contacts whose name contain "Alice" or who have tags that contain "friend"
+* `list -n alice -t friend` Lists out all contacts whose name is "alice" and have the "friend" tag
+* `list --any -n alice -t friend` Lists out all contacts whose name is "alice" or who have the "friend" tag
+* `list --exact -n alice -t friend` Lists out all contacts whose name contain "alice" and who have tags that contain "friend"
+* `list --exact --any -n alice -t friend` Lists out all contacts whose name contain "alice" or who have tags that contain "friend"
 
-## Event List Commands
+### Event List Commands
 
-### Adding events : `eadd`
+#### Adding events : `eadd`
 
 Adds an event to PartyPlanet's Events list. Similar to `add` for person contacts.
 
@@ -170,7 +203,7 @@ Format: `eadd -n NAME [-d DATE] [-r DETAIL]`
 Examples:
 * `eadd -n April Fools -d 2021-04-01 -r Prank the april babies!` Adds a new event April Fools with specified details.
 
-### Editing events : `eedit`
+#### Editing events : `eedit`
 
 Edits an existing event in PartyPlanet's Events List. Similar to `edit`.
 
@@ -183,7 +216,7 @@ Format: `eedit INDEX [-n NAME] [-d DATE] [-r DETAIL]`
 Examples:
 * `eedit 3 -r Celebrate during first combined practice` Edits the remark of the 3rd event to specified remark.
 
-### Listing events: `elist`
+#### Listing events: `elist`
 
 Shows a list of all events in PartyPlanet's Event List. Similar to `list`.
 
@@ -207,7 +240,7 @@ Examples:
 * `elist --any -n Christmas -r tarts` Lists out all events whose name contains "Christmas" or whose remarks contain "tarts"
 * `elist -s d` Lists out all events in chronological order
 
-### Marking events as done : `edone`
+#### Marking events as done : `edone`
 
 Marks event(s) in PartyPlanet's Events List as done.
 
@@ -218,7 +251,7 @@ Format: `edone INDEX [INDEX]…​`
 Examples:
 * `edone 2 3 5` Marks the 2nd, 3rd and 5th events as done.
 
-### Deleting events : `edelete`
+#### Deleting events : `edelete`
 
 Deletes event(s) from PartyPlanet's Events List. Similar to `delete`.
 
@@ -235,9 +268,9 @@ Examples:
 * `edelete` deletes all events in the current Events List.
 * `edelete 1 2 3` deletes events at 1st, 2nd and 3rd indexes.
 
-## General Commmands
+### General Commmands
 
-### Showing help : `help`
+#### Showing help : `help`
 
 Shows a message explaining a list of available commands.
 
@@ -251,7 +284,7 @@ Examples:
 * `help` lists all available commands.
 * `help list` shows the syntax and description for the `list` command.
 
-### Autocomplete: `TAB`
+#### Autocomplete: `TAB`
 
 The Autocomplete feature helps autocomplete when editing a Person or an Event to save the user time from retyping details. Currently, the feature only works for commands `edit` and `eedit`.
 
@@ -265,7 +298,7 @@ EEdit: `eedit INDEX [-n NAME] [-d DATE] [-r DETAIL] TAB`
 
 Note: Valid INDEX must be used in order for Autocomplete to function.
 
-### Undoing actions : `undo`
+#### Undoing actions : `undo`
 
 Undoes the most recent action that changed PartyPlanet's Contact or Event List.
 Can be invoked repeatedly until there is no more history from the current session.
@@ -274,7 +307,7 @@ Format: `undo`
 
 Shortcut: `CTRL + Z`
 
-### Redoing actions : `redo`
+#### Redoing actions : `redo`
 
 Redoes the previous action that changed PartyPlanet's Contact or Event List.
 Can be invoked repeatedly until there are no more previously executed actions from the current session.
@@ -283,19 +316,19 @@ Format: `redo`
 
 Shortcut: `CTRL + SHIFT + Z` or `CTRL + Y`
 
-### Toggle theme : `theme`
+#### Toggle theme : `theme`
 
 Toggles between Dark and Pastel theme
 
 Format: `theme`
 
-### Leaving app : `exit`
+#### Leaving app : `exit`
 
 Exits the app.
 
 Format: `exit`
 
-### InputHistory / Keyboard shortcuts :
+#### InputHistory / Keyboard shortcuts :
 
 Retrieves previously entered input.
 
@@ -339,7 +372,7 @@ Action | Format, Examples
 **EDone** | `edone INDEX [INDEX]…​` <br> e.g. `edone 2 3 5`
 **Edit** | `edit {INDEX [-n NAME] [-p PHONE] [-e EMAIL] [-a ADDRESS] [-t TAG]…​ [-b BIRTHDAY] [-r DETAIL] | --remove -t TAG [-t TAG}…​}`<br> e.g.,`edit 2 -n James Lee -e jameslee@example.com`<br> e.g., `edit --remove -t colleague`
 **EEdit** | `eedit INDEX [-n NAME] [-d DATE] [-r DETAIL]` <br> e.g. `eedit 3 -r Celebrate during first combined practice`
-**List** | `list [-s SORT_ORDER]`<br> e.g., `list`<br> e.g., `list -s asc`
+**List** | `list [--exact] [--any] [-n NAME]... [-t TAG]... [-b BIRTHDAY] [-s SORT_FIELD] [-o SORT_ORDER]`<br> e.g., `list`<br> e.g., `list -s asc`
 **EList** | `elist [--exact] [--any] [-n NAME] [-r DETAIL] ... [-s SORT] [-o ORDER]` <br> e.g. `elist --any -n Christmas -r tarts`
 **Undo** | `undo`
 **Redo** | `redo`


### PR DESCRIPTION
1. Add relevant prefix to each parameter in the parameter table
2. Add overarching summary of commands
3. Change wording of command description to be a little more consistent across different commands (for contact list)
   - Followed existing `delete` command writing style
4. Add missing birthday parameter for `list`, and missing "upcoming" option for list sorting