### PR TITLE
Change email regex to be more permissive

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -58,7 +58,7 @@ PartyPlanet can get the planning of your birthday celebrations done faster than 
 | `COMMAND` | - | - | Any valid command listed [below](#party-planet-commands) |
 | `DATE` | `-d`, `--date` | Event | Valid date with a year:{::nomarkdown}<ul><li>Year must be present and non-negative</li><li>See <code>BIRTHDAY</code> parameter above for available date formats</li></ul>{:/} |
 | `DETAIL` | `-r`, `--remark` | Event | Any value |
-| `EMAIL` | `-e`, `--email` | Contact | In the format `USER@DOMAIN`:{::nomarkdown}<ul><li><code>USER</code> can only contain alphanumerics and any of <code>!#$%&'*+/=?`{&#124;}~^.-</code></li><li><code>DOMAIN</code> must be at least two characters long, start and end with two alphanumerics, and consist only of alphanumerics, periods or hyphens</li></ul>{:/} |
+| `EMAIL` | `-e`, `--email` | Contact | In the format `USER@DOMAIN`:{::nomarkdown}<ul><li><code>USER</code> can only contain alphanumerics and any of <code>!#$%&'*+/=?`{&#124;}~^.-</code></li><li><code>DOMAIN</code> must comprise at least one non-empty label with an optional trailing period.</li><li>A label contains at least one of alphanumerics, hyphens or underscores.</li></ul>{:/} |
 | `INDEX` | - | any | Positive integer representing the ID present in the filtered list |
 | `NAME` | `-n`, `--name` | any | Any value containing only alphanumerics and spaces, unique to the contact/event list (case-sensitive) |
 | `PHONE` | `-p`, `--phone` | Contact | Any number at least three digits long |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -58,7 +58,7 @@ PartyPlanet can get the planning of your birthday celebrations done faster than 
 | `COMMAND` | - | - | Any valid command listed [below](#party-planet-commands) |
 | `DATE` | `-d`, `--date` | Event | Valid date with a year:{::nomarkdown}<ul><li>Year must be present and non-negative</li><li>See <code>BIRTHDAY</code> parameter above for available date formats</li></ul>{:/} |
 | `DETAIL` | `-r`, `--remark` | Event | Any value |
-| `EMAIL` | `-e`, `--email` | Contact | In the format `USER@DOMAIN`:{::nomarkdown}<ul><li><code>USER</code> can only contain alphanumerics and any of <code>!#$%&'*+/=?`{&#124;}~^.-</code></li><li><code>DOMAIN</code> must comprise at least one non-empty label with an optional trailing period.</li><li>A label contains at least one of alphanumerics, hyphens or underscores.</li></ul>{:/} |
+| `EMAIL` | `-e`, `--email` | Contact | In the format `USER@DOMAIN`:{::nomarkdown}<ul><li><code>USER</code> can only contain alphanumerics and any of <code>!#$%&'*+/=?`{&#124;}~^.-</code></li><li><code>DOMAIN</code> must comprise at least one non-empty label with an optional trailing period.</li><li>A label contains at least one of alphanumerics or underscores, with optional hyphens. Labels cannot start with a hyphen.</li></ul>{:/} |
 | `INDEX` | - | any | Positive integer representing the ID present in the filtered list |
 | `NAME` | `-n`, `--name` | any | Any value containing only alphanumerics and spaces, unique to the contact/event list (case-sensitive) |
 | `PHONE` | `-p`, `--phone` | Contact | Any number at least three digits long |

--- a/src/main/java/seedu/partyplanet/model/person/Email.java
+++ b/src/main/java/seedu/partyplanet/model/person/Email.java
@@ -12,16 +12,17 @@ public class Email {
     public static final String EMPTY_EMAIL_STRING = "";
     public static final Email EMPTY_EMAIL = new Email();
 
-    private static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-_";
+    private static final String SPECIAL_CHARACTERS = "_!#$%&'*+/=?`{|}~^.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format USER@DOMAIN "
             + "and adhere to the following constraints:\n"
             + "1. USER can only contain alphanumerics and any of these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + ") .\n"
             + "2. DOMAIN must comprise at least one non-empty label with an optional trailing period.\n"
-            + "3. A label contains at least one of alphanumerics, hyphens or underscores.";
+            + "3. A label contains at least one of alphanumerics or underscores, with optional hyphens. "
+            + "Labels cannot start with a hyphen.";
     // alphanumeric and special characters
     private static final String LOCAL_PART_REGEX = "^[\\w" + SPECIAL_CHARACTERS + "]+";
-    private static final String DOMAIN_REGEX = "([\\w_-]+\\.?)+$";
+    private static final String DOMAIN_REGEX = "(\\w[\\w-]*\\.?)+$";
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;

--- a/src/main/java/seedu/partyplanet/model/person/Email.java
+++ b/src/main/java/seedu/partyplanet/model/person/Email.java
@@ -13,22 +13,16 @@ public class Email {
     public static final Email EMPTY_EMAIL = new Email();
 
     private static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
+    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format USER@DOMAIN "
             + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
+            + "1. USER can only contain alphanumerics and any of these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + ") .\n"
-            + "2. This is followed by a '@' and then a domain name. "
-            + "The domain name must:\n"
-            + "    - be at least 2 characters long\n"
-            + "    - start and end with alphanumeric characters\n"
-            + "    - consist of alphanumeric characters, a period or a hyphen for the characters in between, if any.";
+            + "2. DOMAIN must comprise at least one non-empty label with an optional trailing period.\n"
+            + "3. A label contains at least one of alphanumerics, hyphens or underscores.";
     // alphanumeric and special characters
     private static final String LOCAL_PART_REGEX = "^[\\w" + SPECIAL_CHARACTERS + "]+";
-    private static final String DOMAIN_FIRST_CHARACTER_REGEX = "[^\\W_]"; // alphanumeric characters except underscore
-    private static final String DOMAIN_MIDDLE_REGEX = "[a-zA-Z0-9.-]*"; // alphanumeric, period and hyphen
-    private static final String DOMAIN_LAST_CHARACTER_REGEX = "[^\\W_]$";
-    public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@"
-            + DOMAIN_FIRST_CHARACTER_REGEX + DOMAIN_MIDDLE_REGEX + DOMAIN_LAST_CHARACTER_REGEX;
+    private static final String DOMAIN_REGEX = "([\\w_-]+\\.?)+$";
+    public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;
     private boolean isEmpty = false;

--- a/src/main/java/seedu/partyplanet/model/person/Email.java
+++ b/src/main/java/seedu/partyplanet/model/person/Email.java
@@ -12,7 +12,7 @@ public class Email {
     public static final String EMPTY_EMAIL_STRING = "";
     public static final Email EMPTY_EMAIL = new Email();
 
-    private static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-";
+    private static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-_";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format USER@DOMAIN "
             + "and adhere to the following constraints:\n"
             + "1. USER can only contain alphanumerics and any of these special characters, excluding "

--- a/src/test/java/seedu/partyplanet/model/person/EmailTest.java
+++ b/src/test/java/seedu/partyplanet/model/person/EmailTest.java
@@ -34,8 +34,6 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@")); // missing domain name
 
         // invalid parts
-        assertFalse(Email.isValidEmail("peterjack@-")); // invalid domain name
-        assertFalse(Email.isValidEmail("peterjack@exam_ple.com")); // underscore in domain name
         assertFalse(Email.isValidEmail("peter jack@example.com")); // spaces in local part
         assertFalse(Email.isValidEmail("peterjack@exam ple.com")); // spaces in domain name
         assertFalse(Email.isValidEmail(" peterjack@example.com")); // leading space
@@ -44,13 +42,15 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
         assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
         assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
-        assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
-        assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
-        assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com"));
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
+        assertTrue(Email.isValidEmail("peterjack@-")); // valid domain name
+        assertTrue(Email.isValidEmail("peterjack@exam_ple.com")); // underscore in domain name
+        assertTrue(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
+        assertTrue(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
+        assertTrue(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
+        assertTrue(Email.isValidEmail("a@b.c")); // minimal
         assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
         assertTrue(Email.isValidEmail("!#$%&'*+/=?`{|}~^.-@example.org")); // special characters local part
         assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name

--- a/src/test/java/seedu/partyplanet/model/person/EmailTest.java
+++ b/src/test/java/seedu/partyplanet/model/person/EmailTest.java
@@ -43,19 +43,22 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
         assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
 
-        // valid email
+        // valid email - user test
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com"));
-        assertTrue(Email.isValidEmail("peterjack@-")); // valid domain name
-        assertTrue(Email.isValidEmail("peterjack@exam_ple.com")); // underscore in domain name
-        assertTrue(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
-        assertTrue(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
-        assertTrue(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
-        assertTrue(Email.isValidEmail("a@b.c")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("!#$%&'*+/=?`{|}~^.-@example.org")); // special characters local part
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
+        assertTrue(Email.isValidEmail("!#$%&'*+/=?`{|}~^.-_@example.org")); // special characters local part
         assertTrue(Email.isValidEmail("a1+be!@example1.com")); // mixture of alphanumeric and special characters
-        assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
+        assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name, with dash
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
+
+        // domain test
+        assertTrue(Email.isValidEmail("peterjack@a")); // minimal
+        assertTrue(Email.isValidEmail("peterjack@0")); // minimal
+        assertTrue(Email.isValidEmail("peterjack@a-")); // minimal with dash
+        assertTrue(Email.isValidEmail("peterjack@_")); // start with underscore
+        assertTrue(Email.isValidEmail("peterjack@a.")); // ends in period
+        assertTrue(Email.isValidEmail("peterjack@localhost")); // all text
+        assertTrue(Email.isValidEmail("peterjack@192.168.1.23")); // IP address (IPv4)
+        assertTrue(Email.isValidEmail("peterjack@web.example.com.")); // multiple periods
+        assertFalse(Email.isValidEmail("peterjack@-")); // cannot start with dash
     }
 }


### PR DESCRIPTION
Resolves #247. Changed the user guide, and updated the help command to match it as well.

Matching of false positives in and of itself is not a bug per se, since this is more for client-side verification. We can also take this opportunity to make the regular expression more permissive to avoid matching false negatives (i.e. wrongly reject valid user email) which is a bigger problem. Some examples of valid domains for this updated regex:

- `192.168.1.23`
- `localhost`
- `smtp.google.com.`
- `jabber._tcp.gmail.com` (valid, previously false negative)
- `-` (negative)
- `-.` (negative)
- `a-.` (positive)

By extension, weird ones are also accepted, but this is of course subject to change in future RFCs. Let's avoid going down the slippery slope of testing for Unicode international domain names as well.

The full regex used for the email format (ignoring the special characters in the front) is `^[\w]+@([\w-]\.?)+$`.
This can be tested using the following link: https://regexr.com/5q119