### PR TITLE
Fix: pressing up key once after a command with an error does not revert to earlier input

### DIFF
--- a/src/main/java/seedu/partyplanet/ui/CommandBox.java
+++ b/src/main/java/seedu/partyplanet/ui/CommandBox.java
@@ -57,6 +57,8 @@ public class CommandBox extends UiPart<Region> {
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+            // As input is not cleared, history begins at 2nd last (which is the current input, instead of blank)
+            history.getPrevious();
         }
     }
 


### PR DESCRIPTION
Fixes #272 

Since textfield does not clear on invalid input, input history should start at the latest text instead of blank.