### PR TITLE
Fix long words in fields getting pushed to next line

### DIFF
--- a/src/main/java/seedu/partyplanet/ui/EventCard.java
+++ b/src/main/java/seedu/partyplanet/ui/EventCard.java
@@ -63,7 +63,7 @@ public class EventCard extends UiPart<Region> {
      */
     private void addDetail(String detail) {
         Label label = new Label();
-        label.setText("\u2022 " + detail);
+        label.setText("\u2022" + detail);
         label.setWrapText(true);
         label.getStyleClass().add("cell_small_label");
         details.getChildren().add(label);

--- a/src/main/java/seedu/partyplanet/ui/PersonCard.java
+++ b/src/main/java/seedu/partyplanet/ui/PersonCard.java
@@ -77,7 +77,7 @@ public class PersonCard extends UiPart<Region> {
      */
     private void addDetail(String detail) {
         Label label = new Label();
-        label.setText("\u2022 " + detail);
+        label.setText("\u2022" + detail);
         label.setWrapText(true);
         label.getStyleClass().add("cell_small_label");
         details.getChildren().add(label);


### PR DESCRIPTION
Part of #223 

Fixes problem where long words in field get pushed to next line

Problem:
![image](https://user-images.githubusercontent.com/71179511/113510641-5a6e3a00-958e-11eb-97db-7ac60eb6f675.png)

Fixed:
![image](https://user-images.githubusercontent.com/71179511/113510662-77a30880-958e-11eb-8abb-df3afcf9fa92.png)

