### PR TITLE
Fixes several unclear parts of UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -32,10 +32,10 @@ PartyPlanet can get the planning of your birthday celebrations done faster than 
 * Words in `UPPER_CASE` are the parameters to be supplied by the user.<br>
   e.g. in `add -n NAME`, `NAME` is a parameter which can be used as `add -n John Doe`.
 
-* Items in square brackets are optional.<br>
+* Parameters in square brackets are optional.<br>
   e.g. `-n NAME [-t TAG]` can be used as `-n John Doe -t friend` or as `-n John Doe`.
 
-* Items with `...` after them can be used any number of times.<br>
+* Parameters with `...` after them can be used any number of times.<br>
   e.g. `[-t TAG]...` can be used as ` `, `-t friend`, `-t friend -t family` etc.
 
 * Parameters can be in any order.<br>
@@ -46,6 +46,11 @@ PartyPlanet can get the planning of your birthday celebrations done faster than 
 
 * Extraneous parameters for commands that do not take in parameters (such as `exit` and `undo`) will be ignored.<br>
   e.g. if the command specifies `exit 123`, it will be interpreted as `exit`.
+
+* Parameters in `{}` represents mutually-exclusive parameters.<br>
+  Each mutually-exclusve parameter is separated by a `|`.<br>
+  e.g. `command {foo | bar}` means that either `command foo` or `command bar` are valid commands.<br>
+  However `command foo bar` is an invalid command.
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -313,7 +313,8 @@ Note: Valid INDEX must be used in order for Autocomplete to function.
 #### Undoing actions : `undo`
 
 Undoes the most recent action that changed PartyPlanet's Contact or Event List.<br>
-Note: This means that only commands such as `add`, `delete` etc.. can be undoed. Other changes such as `theme` will not be affected.
+Note: This means that only commands such, as `add`, `delete` etc.., can be undoed.<br>
+Other command that only changes display, such as `theme`, `list` etc.., will not be affected.
 
 Can be invoked repeatedly until there is no more history from the current session.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -23,37 +23,6 @@ PartyPlanet can get the planning of your birthday celebrations done faster than 
 
 --------------------------------------------------------------------------------------------------------------------
 
-## Features
-
-<div markdown="block" class="alert alert-info">
-
-**:information_source: Notes about the command format:**<br>
-
-* Words in `UPPER_CASE` are the parameters to be supplied by the user.<br>
-  e.g. in `add -n NAME`, `NAME` is a parameter which can be used as `add -n John Doe`.
-
-* Parameters in square brackets are optional.<br>
-  e.g. `-n NAME [-t TAG]` can be used as `-n John Doe -t friend` or as `-n John Doe`.
-
-* Parameters with `...` after them can be used any number of times.<br>
-  e.g. `[-t TAG]...` can be used as ` `, `-t friend`, `-t friend -t family` etc.
-
-* Parameters can be in any order.<br>
-  e.g. if the command specifies `-n NAME -p PHONE`, the alternative `-p PHONE -n NAME` is also acceptable.
-
-* If a parameter is expected only once in the command, but you specified it multiple times, only the last occurrence of the parameter will be taken.<br>
-  e.g. if you specify `-p 12341234 -p 56785678`, only `-p 56785678` will be taken.
-
-* Extraneous parameters for commands that do not take in parameters (such as `exit` and `undo`) will be ignored.<br>
-  e.g. if the command specifies `exit 123`, it will be interpreted as `exit`.
-
-* Parameters in `{}` represents mutually-exclusive parameters.<br>
-  Each mutually-exclusve parameter is separated by a `|`.<br>
-  e.g. `command {foo | bar}` means that either `command foo` or `command bar` are valid commands.<br>
-  However `command foo bar` is an invalid command.
-
-</div>
-
 ## Glossary of parameters
 
 | Parameter | Prefix | Applicable to | Description |
@@ -87,7 +56,40 @@ PartyPlanet can get the planning of your birthday celebrations done faster than 
 
 </div>
 
+--------------------------------------------------------------------------------------------------------------------
+
 ## Party Planet Commands
+
+## Command syntax
+
+<div markdown="block" class="alert alert-info">
+
+**:information_source: Notes about the command format:**<br>
+
+* Words in `UPPER_CASE` are the parameters to be supplied by the user.<br>
+  e.g. in `add -n NAME`, `NAME` is a parameter which can be used as `add -n John Doe`.
+
+* Parameters in square brackets are optional.<br>
+  e.g. `-n NAME [-t TAG]` can be used as `-n John Doe -t friend` or as `-n John Doe`.
+
+* Parameters with `...` after them can be used any number of times.<br>
+  e.g. `[-t TAG]...` can be used as ` `, `-t friend`, `-t friend -t family` etc.
+
+* Parameters can be in any order.<br>
+  e.g. if the command specifies `-n NAME -p PHONE`, the alternative `-p PHONE -n NAME` is also acceptable.
+
+* If a parameter is expected only once in the command, but you specified it multiple times, only the last occurrence of the parameter will be taken.<br>
+  e.g. if you specify `-p 12341234 -p 56785678`, only `-p 56785678` will be taken.
+
+* Extraneous parameters for commands that do not take in parameters (such as `exit` and `undo`) will be ignored.<br>
+  e.g. if the command specifies `exit 123`, it will be interpreted as `exit`.
+
+* Parameters in `{}` represents mutually-exclusive parameters.<br>
+  Each mutually-exclusve parameter is separated by a `|`.<br>
+  e.g. `command {foo | bar}` means that either `command foo` or `command bar` are valid commands.<br>
+  However `command foo bar` is an invalid command.
+
+</div>
 
 ### Summary
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -60,8 +60,6 @@ PartyPlanet can get the planning of your birthday celebrations done faster than 
 
 ## Party Planet Commands
 
-## Command syntax
-
 <div markdown="block" class="alert alert-info">
 
 **:information_source: Notes about the command format:**<br>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -302,9 +302,9 @@ The Autocomplete feature helps autocomplete when editing a Person or an Event to
 
 For any valid and empty prefix that the user inputs, the relevant details will be autocompleted on `TAB` keypress down.
 
-Format: 
+Format:
 
-Edit: `edit INDEX [-n NAME] [-p PHONE] [-e EMAIL] [-a ADDRESS] [-t TAG]…​ [-b BIRTHDAY] [-r REMARK] TAB` 
+Edit: `edit INDEX [-n NAME] [-p PHONE] [-e EMAIL] [-a ADDRESS] [-t TAG]…​ [-b BIRTHDAY] [-r REMARK] TAB`
 
 EEdit: `eedit INDEX [-n NAME] [-d DATE] [-r DETAIL] TAB`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -312,7 +312,9 @@ Note: Valid INDEX must be used in order for Autocomplete to function.
 
 #### Undoing actions : `undo`
 
-Undoes the most recent action that changed PartyPlanet's Contact or Event List.
+Undoes the most recent action that changed PartyPlanet's Contact or Event List.<br>
+Note: This means that only commands such as `add`, `delete` etc.. can be undoed. Other changes such as `theme` will not be affected.
+
 Can be invoked repeatedly until there is no more history from the current session.
 
 Format: `undo`
@@ -322,6 +324,7 @@ Shortcut: `CTRL + Z`
 #### Redoing actions : `redo`
 
 Redoes the previous action that changed PartyPlanet's Contact or Event List.
+
 Can be invoked repeatedly until there are no more previously executed actions from the current session.
 
 Format: `redo`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -312,7 +312,8 @@ Note: Valid INDEX must be used in order for Autocomplete to function.
 
 #### Undoing actions : `undo`
 
-Undoes the most recent action that changed PartyPlanet's Contact or Event List.<br>
+Undoes the most recent action that changed PartyPlanet's Contact or Event List.
+
 Note: This means that only commands such, as `add`, `delete` etc.., can be undoed.<br>
 Other command that only changes display, such as `theme`, `list` etc.., will not be affected.
 

--- a/docs/developerGuide/requirements/UseCases.md
+++ b/docs/developerGuide/requirements/UseCases.md
@@ -144,7 +144,7 @@ MSS:
 
 
 
-Use case: UC13 - Undo an action 
+Use case: UC13 - Undo an action
 MSS:
   1. User requests to undo an action.
   2. PartyPlanet displays the details of the action that was undone and the list of contacts/events after the action is undone.

--- a/docs/team/justin.md
+++ b/docs/team/justin.md
@@ -42,7 +42,7 @@ A full list of code contribution can be found here:
   [\#111](https://github.com/AY2021S2-CS2103-W16-3/tp/pull/111)
 - Proposed command list consolidation to remove `tags`, `find`, `clear`.
 - Update GUI visuals, usability feature:
-  [\#198](https://github.com/AY2021S2-CS2103-W16-3/tp/pull/198) 
+  [\#198](https://github.com/AY2021S2-CS2103-W16-3/tp/pull/198)
 - Refactor theme toggling command to use enumeration instead, add GUI option to toggle theme:
   [\#184](https://github.com/AY2021S2-CS2103-W16-3/tp/pull/184)
   builds on


### PR DESCRIPTION
Fixes #239 Fixes #222 
Clarified further functionality for undo

>Note: This means that only commands such, as `add`, `delete` etc.., can be undoed.<br>
>Other command that only changes display, such as `theme`, `list` etc.., will not be affected.


Fixes #264 
Shift notes about command format to more appropriate place, at the start of `PartyPlanet Commands`

Fixes #265 
Add definition of mututally exclusive `{}` to notes about command format

Clean up trailing whitespaces
