### PR TITLE
Prevent display from returning back to main list after edit

### DIFF
--- a/src/main/java/seedu/partyplanet/logic/commands/EEditCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/EEditCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_REMARK;
-import static seedu.partyplanet.model.Model.PREDICATE_SHOW_ALL_EVENTS;
 
 import java.util.List;
 import java.util.Optional;
@@ -78,7 +77,6 @@ public class EEditCommand extends Command {
 
         model.setEvent(eventToEdit, editedEvent);
         model.addState(String.format(MESSAGE_EDIT_EVENT_SUCCESS, editedEvent));
-        model.updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
         return new CommandResult(String.format(MESSAGE_EDIT_EVENT_SUCCESS, editedEvent));
     }
 

--- a/src/main/java/seedu/partyplanet/logic/commands/EditFieldCommand.java
+++ b/src/main/java/seedu/partyplanet/logic/commands/EditFieldCommand.java
@@ -1,7 +1,6 @@
 package seedu.partyplanet.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.partyplanet.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -59,7 +58,6 @@ public class EditFieldCommand extends EditCommand {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         String output = String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
         model.addState(output);

--- a/src/test/java/seedu/partyplanet/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/partyplanet/logic/commands/EditCommandTest.java
@@ -100,6 +100,7 @@ public class EditCommandTest {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
                 new EventBook(model.getEventBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        showNoPerson(expectedModel);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -171,6 +172,15 @@ public class EditCommandTest {
 
         // different descriptor -> returns false
         assertFalse(standardCommand.equals(new EditFieldCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoPerson(Model model) {
+        model.updateFilteredPersonList(p -> false);
+
+        assertTrue(model.getFilteredPersonList().isEmpty());
     }
 
 }


### PR DESCRIPTION
Fixes #251.

Previously: every successful edit action displays the full list of contacts back to the user.
Now: displayed contacts list remain as filtered list after successful edit actions done to a filtered list
("edit" applies to both `edit` and `eedit`)