### PR TITLE
Update Error Message when index specified as 0

### DIFF
--- a/src/main/java/seedu/partyplanet/logic/autocomplete/EEditAutocompleteUtil.java
+++ b/src/main/java/seedu/partyplanet/logic/autocomplete/EEditAutocompleteUtil.java
@@ -1,6 +1,7 @@
 package seedu.partyplanet.logic.autocomplete;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.partyplanet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_REMARK;
@@ -10,6 +11,7 @@ import java.util.Map;
 
 import javafx.collections.ObservableList;
 import seedu.partyplanet.commons.core.index.Index;
+import seedu.partyplanet.logic.commands.EEditCommand;
 import seedu.partyplanet.logic.commands.exceptions.CommandException;
 import seedu.partyplanet.logic.parser.ArgumentMultimap;
 import seedu.partyplanet.logic.parser.ArgumentTokenizer;
@@ -21,7 +23,7 @@ import seedu.partyplanet.model.event.Event;
 
 public class EEditAutocompleteUtil {
 
-    private static final String INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE = "Index not specified or invalid!";
+    private static final String INDEX_OUT_OF_BOUNDS_ERROR = "Index provided does not match any event!";
 
     /**
      * Parses an edit command to autocomplete remark.
@@ -40,12 +42,12 @@ public class EEditAutocompleteUtil {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble().split(" ")[0]);
         } catch (ParseException pe) {
-            throw new ParseException(INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EEditCommand.MESSAGE_USAGE), pe);
         }
 
         ObservableList<Event> filteredEventsList = model.getFilteredEventList();
         if (index.getZeroBased() >= filteredEventsList.size()) {
-            throw new CommandException(INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE);
+            throw new CommandException(INDEX_OUT_OF_BOUNDS_ERROR);
         }
 
         Event event = filteredEventsList.get(index.getZeroBased());

--- a/src/main/java/seedu/partyplanet/logic/autocomplete/EEditAutocompleteUtil.java
+++ b/src/main/java/seedu/partyplanet/logic/autocomplete/EEditAutocompleteUtil.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 
 import javafx.collections.ObservableList;
-import seedu.partyplanet.commons.core.Messages;
 import seedu.partyplanet.commons.core.index.Index;
 import seedu.partyplanet.logic.commands.exceptions.CommandException;
 import seedu.partyplanet.logic.parser.ArgumentMultimap;
@@ -46,7 +45,7 @@ public class EEditAutocompleteUtil {
 
         ObservableList<Event> filteredEventsList = model.getFilteredEventList();
         if (index.getZeroBased() >= filteredEventsList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+            throw new CommandException(INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE);
         }
 
         Event event = filteredEventsList.get(index.getZeroBased());

--- a/src/main/java/seedu/partyplanet/logic/autocomplete/EEditAutocompleteUtil.java
+++ b/src/main/java/seedu/partyplanet/logic/autocomplete/EEditAutocompleteUtil.java
@@ -22,7 +22,7 @@ import seedu.partyplanet.model.event.Event;
 
 public class EEditAutocompleteUtil {
 
-    private static final String INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE = "Index not specified!";
+    private static final String INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE = "Index not specified or Invalid!";
 
     /**
      * Parses an edit command to autocomplete remark.

--- a/src/main/java/seedu/partyplanet/logic/autocomplete/EEditAutocompleteUtil.java
+++ b/src/main/java/seedu/partyplanet/logic/autocomplete/EEditAutocompleteUtil.java
@@ -22,7 +22,7 @@ import seedu.partyplanet.model.event.Event;
 
 public class EEditAutocompleteUtil {
 
-    private static final String INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE = "Index not specified or Invalid!";
+    private static final String INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE = "Index not specified or invalid!";
 
     /**
      * Parses an edit command to autocomplete remark.

--- a/src/main/java/seedu/partyplanet/logic/autocomplete/EditAutocompleteUtil.java
+++ b/src/main/java/seedu/partyplanet/logic/autocomplete/EditAutocompleteUtil.java
@@ -1,6 +1,7 @@
 package seedu.partyplanet.logic.autocomplete;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.partyplanet.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.partyplanet.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -17,6 +18,7 @@ import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import seedu.partyplanet.commons.core.index.Index;
+import seedu.partyplanet.logic.commands.EditCommand;
 import seedu.partyplanet.logic.commands.exceptions.CommandException;
 import seedu.partyplanet.logic.parser.ArgumentMultimap;
 import seedu.partyplanet.logic.parser.ArgumentTokenizer;
@@ -29,7 +31,7 @@ import seedu.partyplanet.model.tag.Tag;
 
 public class EditAutocompleteUtil {
 
-    private static final String INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE = "Index not specified or invalid!";
+    private static final String INDEX_OUT_OF_BOUNDS_ERROR = "Index provided does not match any user!";
 
     /**
      * Used to convert Set of {@code Tag}s into a String with Tag Prefixes.
@@ -59,12 +61,12 @@ public class EditAutocompleteUtil {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble().split(" ")[0]);
         } catch (ParseException pe) {
-            throw new ParseException(INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
         ObservableList<Person> filteredPersonList = model.getFilteredPersonList();
         if (index.getZeroBased() >= filteredPersonList.size()) {
-            throw new CommandException(INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE);
+            throw new CommandException(INDEX_OUT_OF_BOUNDS_ERROR);
         }
 
         Person person = filteredPersonList.get(index.getZeroBased());

--- a/src/main/java/seedu/partyplanet/logic/autocomplete/EditAutocompleteUtil.java
+++ b/src/main/java/seedu/partyplanet/logic/autocomplete/EditAutocompleteUtil.java
@@ -16,7 +16,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
-import seedu.partyplanet.commons.core.Messages;
 import seedu.partyplanet.commons.core.index.Index;
 import seedu.partyplanet.logic.commands.exceptions.CommandException;
 import seedu.partyplanet.logic.parser.ArgumentMultimap;
@@ -65,7 +64,7 @@ public class EditAutocompleteUtil {
 
         ObservableList<Person> filteredPersonList = model.getFilteredPersonList();
         if (index.getZeroBased() >= filteredPersonList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(INDEX_NOT_SPECIFIED_OR_INVALID_MESSAGE);
         }
 
         Person person = filteredPersonList.get(index.getZeroBased());


### PR DESCRIPTION
When command `eedit 0 TAB` is run, change return error message from "Index not specified!" to "Index not specified or Invalid!".

Closes #263