### PR TITLE
Fix error message bug for `delete` using tags

### DIFF
--- a/src/main/java/seedu/partyplanet/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/DeleteCommandParser.java
@@ -43,18 +43,11 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             return new DeleteClearCommand();
         }
 
-        try {
-
-            if (tagIsPresent) {
-                return createDeleteContactWithTagCommand(argMultimap.getAllValues(PREFIX_TAG), isAny);
-            }
-
-            return createDeleteContactCommand(argMultimap.getPreamble());
-
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+        if (tagIsPresent) {
+            return createDeleteContactWithTagCommand(argMultimap.getAllValues(PREFIX_TAG), isAny);
         }
+
+        return createDeleteContactCommand(argMultimap.getPreamble());
     }
 
     private DeleteContactWithTagCommand createDeleteContactWithTagCommand(List<String> tags, boolean isAny)

--- a/src/main/java/seedu/partyplanet/logic/parser/EDeleteCommandParser.java
+++ b/src/main/java/seedu/partyplanet/logic/parser/EDeleteCommandParser.java
@@ -31,14 +31,7 @@ public class EDeleteCommandParser implements Parser<EDeleteCommand> {
             return new EDeleteClearCommand();
         }
 
-        try {
-
-            return createEDeleteEventCommand(argMultimap.getPreamble());
-
-        } catch (ParseException pe) {
-            throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EDeleteCommand.MESSAGE_USAGE), pe);
-        }
+        return createEDeleteEventCommand(argMultimap.getPreamble());
     }
 
 

--- a/src/test/java/seedu/partyplanet/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/partyplanet/logic/parser/DeleteCommandParserTest.java
@@ -102,8 +102,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_emptyTags_throwsParseException() {
-        assertParseFailure(parser, " -t ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, " --any -t ",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " -t ", Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " --any -t ", Tag.MESSAGE_CONSTRAINTS);
     }
 }


### PR DESCRIPTION
Remove redundant try catch from DeleteCommandParser and EDeleteCommandParser (was basically catching and throwing back the same error)
Which also fixes wrong error message for `delete` command using tags

Before:
![image](https://user-images.githubusercontent.com/71179511/114277324-4a0e0180-9a5d-11eb-8970-c12766068743.png)

After:
![image](https://user-images.githubusercontent.com/71179511/114277301-36fb3180-9a5d-11eb-95f2-f578416adb02.png)
